### PR TITLE
Fix for JSIP-519: OriginFieldParser skips session id and session version

### DIFF
--- a/src/gov/nist/javax/sdp/parser/OriginFieldParser.java
+++ b/src/gov/nist/javax/sdp/parser/OriginFieldParser.java
@@ -59,11 +59,11 @@ public class OriginFieldParser extends SDPParser {
             Token sessionId = lexer.getNextToken();
             // guard against very long session IDs
             String sessId = sessionId.getTokenValue();
-            if (sessId.length() > 18)
-                sessId = sessId.substring(sessId.length() - 18);
             try {
                 originField.setSessId(Long.parseLong(sessId));
             } catch (NumberFormatException ex) {
+                if (sessId.length() > 18)
+                    sessId = sessId.substring(sessId.length() - 18);
                 originField.setSessionId(sessId);
             }
             this.lexer.SPorHT();
@@ -72,11 +72,11 @@ public class OriginFieldParser extends SDPParser {
             Token sessionVersion = lexer.getNextToken();
             // guard against very long session Verion
             String sessVer = sessionVersion.getTokenValue();
-            if (sessVer.length() > 18)
-                sessVer = sessVer.substring(sessVer.length() - 18);
             try {
                 originField.setSessVersion(Long.parseLong(sessVer));
             } catch (NumberFormatException ex) {
+                if (sessVer.length() > 18)
+                    sessVer = sessVer.substring(sessVer.length() - 18);
                 originField.setSessVersion(sessVer);
 
             }


### PR DESCRIPTION
Although SDP RFC 4566 does not limit the sess-id and sess-version field the NIST implementation of gov.nist.javax.sdp.parser.OriginFieldParser limits the fields to 18 digits.
This has been done because the jain.sip API used a Java long field for the session-id and session-version.
Unfortunately the JAVA long allows up to 19 digits (see Long.MAX_VALUE) which means that the SDP parser does not allow the full possible range of values to be used with JAVA long.
The Mozilla Firefox Browser in WebRTC environment created SDP containing the session-id value using the full range for the long value and therefore the first digit may be cut by the current code of OriginFieldParser.java.
My attached simple patch allows to use the full value range of Long.MAX_VALUE.