### PR TITLE
UAS loop detection configuration

### DIFF
--- a/src/gov/nist/javax/sip/DialogFilter.java
+++ b/src/gov/nist/javax/sip/DialogFilter.java
@@ -417,6 +417,7 @@ class DialogFilter implements ServerRequestInterface, ServerResponseInterface {
          * Support.
          */
         if (sipProvider.isDialogErrorsAutomaticallyHandled()
+                && sipProvider.isLoopDetectionEnabled()
                 && sipRequest.getToTag() == null) {
             if (sipStack.findMergedTransaction(sipRequest)) {
                 this.sendLoopDetectedResponse(sipRequest, transaction);

--- a/src/gov/nist/javax/sip/SipProviderExt.java
+++ b/src/gov/nist/javax/sip/SipProviderExt.java
@@ -1,6 +1,7 @@
 package gov.nist.javax.sip;
 
 import javax.sip.SipProvider;
+import javax.sip.SipStack;
 
 /**
  * Extensions to SipProvider under consideration for Version 2.0.
@@ -37,4 +38,30 @@ public interface SipProviderExt extends SipProvider {
      * @since 2.0
      */
     public void setDialogErrorsAutomaticallyHandled();
+    
+    /**
+     * Sets a flag that indicates that loop detection is enabled or disabled for this dialog (the
+     * default when automatic dialog support is enabled). This flag is set by default to TRUE when
+     * the Dialog is automatically created by the provider ( automatic dialog support is true) and
+     * set to FALSE by default when the Dialog is created under program control ( automatic dialog
+     * support is false). When this flag is set to true, the stack will automatically send the
+     * following errors :
+     * 
+     * <ul>
+     * <li> <b>482 Loop Detected </b> When a loop is detected for merged INVITE requests.
+     * </ul>
+     * If this flag is set to false, the stack will not enable loop detection for merged INVITE requests
+     * 
+     * This flag is automatically set to true if any of the the following conditions is true:
+     * <ul>
+     * <li>The Back To Back User Agent flag is enabled for the Dialog.</li>
+     * <li>The Automatic Dialog Support flag is enabled for the Dialog </li>
+     * </ul>
+     * 
+     * This flag should only be set at the time of Dialog creation ( before the Dialog has seen its first
+     * request or response). If set subsequently, the behavior of the flag is undefined.
+     * 
+     * @since 2.0
+     */
+    public void setLoopDetectionEnabled(boolean flag);
 }

--- a/src/gov/nist/javax/sip/SipProviderImpl.java
+++ b/src/gov/nist/javax/sip/SipProviderImpl.java
@@ -116,6 +116,8 @@ public class SipProviderImpl implements javax.sip.SipProvider, gov.nist.javax.si
     
     private boolean dialogErrorsAutomaticallyHandled = true;
     
+    private boolean loopDetectionEnabled = true;
+    
     private SipProviderImpl() {
 
     }
@@ -195,6 +197,7 @@ public class SipProviderImpl implements javax.sip.SipProvider, gov.nist.javax.si
         this.automaticDialogSupportEnabled = this.sipStack
                 .isAutomaticDialogSupportEnabled();
         this.dialogErrorsAutomaticallyHandled = this.sipStack.isAutomaticDialogErrorHandlingEnabled();
+        this.loopDetectionEnabled = this.sipStack.isServerLoopDetectionEnabled();
     }
 
     /*
@@ -1116,7 +1119,19 @@ public class SipProviderImpl implements javax.sip.SipProvider, gov.nist.javax.si
     public boolean isDialogErrorsAutomaticallyHandled() {
         return this.dialogErrorsAutomaticallyHandled;
     }
+    
+    /*
+     * (non-Javadoc)
+     * @see gov.nist.javax.sip.SipProviderExt#setLoopDetectionEnabled(boolean flag)
+     */
+    public void setLoopDetectionEnabled(boolean flag) {
+        this.loopDetectionEnabled = flag;
+    }
 
+
+    public boolean isLoopDetectionEnabled() {
+      return this.loopDetectionEnabled;
+    }
 
     /**
      * @return the sipListener
@@ -1124,6 +1139,7 @@ public class SipProviderImpl implements javax.sip.SipProvider, gov.nist.javax.si
     public SipListener getSipListener() {
         return sipListener;
     }
+
 
    
 }

--- a/src/gov/nist/javax/sip/SipStackImpl.java
+++ b/src/gov/nist/javax/sip/SipStackImpl.java
@@ -934,6 +934,10 @@ public class SipStackImpl extends SIPTransactionStack implements
 		if ( super.isAutomaticDialogSupportEnabled ) {
 			super.isAutomaticDialogErrorHandlingEnabled = true;
 		}
+		
+		super.isServerLoopDetectionEnabled = configurationProperties
+      .getProperty("gov.nist.javax.sip.SERVER_LOOP_DETECTION","on")
+      .equalsIgnoreCase("on");
 	
 		if (configurationProperties
 				.getProperty("gov.nist.javax.sip.MAX_LISTENER_RESPONSE_TIME") != null) {
@@ -1919,6 +1923,10 @@ public class SipStackImpl extends SIPTransactionStack implements
 	public boolean isAutomaticDialogErrorHandlingEnabled() {
 		return super.isAutomaticDialogErrorHandlingEnabled;
 	}
+	
+	public boolean isServerLoopDetectionEnabled() {
+    return super.isServerLoopDetectionEnabled;
+  }
 
 	
 	public void setTlsSecurityPolicy(TlsSecurityPolicy tlsSecurityPolicy) {

--- a/src/gov/nist/javax/sip/stack/SIPTransactionStack.java
+++ b/src/gov/nist/javax/sip/stack/SIPTransactionStack.java
@@ -346,7 +346,9 @@ public abstract class SIPTransactionStack implements
     protected boolean checkBranchId;
 
     protected boolean isAutomaticDialogErrorHandlingEnabled = true;
-
+    
+    protected boolean isServerLoopDetectionEnabled = true;
+    
     protected boolean isDialogTerminatedEventDeliveredForNullDialog = false;
 
     // Max time for a forked response to arrive. After this time, the original

--- a/src/test/unit/gov/nist/javax/sip/stack/forkedinviteloopdisabled/AbstractForkedInviteTestCase.java
+++ b/src/test/unit/gov/nist/javax/sip/stack/forkedinviteloopdisabled/AbstractForkedInviteTestCase.java
@@ -1,0 +1,125 @@
+/**
+ *
+ */
+package test.unit.gov.nist.javax.sip.stack.forkedinviteloopdisabled;
+
+import gov.nist.javax.sip.SipProviderImpl;
+
+import java.util.EventObject;
+import java.util.Hashtable;
+import java.util.Timer;
+import java.util.TimerTask;
+
+import javax.sip.DialogTerminatedEvent;
+import javax.sip.IOExceptionEvent;
+import javax.sip.RequestEvent;
+import javax.sip.ResponseEvent;
+import javax.sip.SipListener;
+import javax.sip.SipProvider;
+import javax.sip.TimeoutEvent;
+import javax.sip.TransactionTerminatedEvent;
+
+import org.apache.log4j.Appender;
+import org.apache.log4j.ConsoleAppender;
+import org.apache.log4j.FileAppender;
+import org.apache.log4j.Logger;
+import org.apache.log4j.PropertyConfigurator;
+import org.apache.log4j.SimpleLayout;
+import org.apache.log4j.helpers.NullEnumeration;
+
+import test.tck.msgflow.callflows.ProtocolObjects;
+import test.tck.msgflow.callflows.ScenarioHarness;
+
+import junit.framework.TestCase;
+
+/**
+ * @author M. Ranganathan
+ *
+ */
+public class AbstractForkedInviteTestCase extends ScenarioHarness implements
+        SipListener {
+
+
+    protected Shootist shootist;
+
+    private static Logger logger = Logger.getLogger("test.tck");
+
+
+    protected Shootme shootme;
+
+    private Proxy proxy;
+
+
+
+    static {
+        if ( !logger.isAttached(console))
+            logger.addAppender(console);
+    }
+
+    // private Appender appender;
+
+    public AbstractForkedInviteTestCase() {
+
+        super("forkedInviteTest", true);
+
+        try {
+            providerTable = new Hashtable();
+
+        } catch (Exception ex) {
+            logger.error("unexpected exception", ex);
+            fail("unexpected exception ");
+        }
+    }
+
+    public void setUp() {
+
+        try {
+            super.setUp(false);
+            shootist = new Shootist(5060, 5070, getTiProtocolObjects());
+            SipProvider shootistProvider = shootist.createSipProvider();
+            providerTable.put(shootistProvider, shootist);
+
+            this.shootme = new Shootme(5080, getTiProtocolObjects());
+            SipProvider shootmeProvider = shootme.createProvider();
+            providerTable.put(shootmeProvider, shootme);
+            shootistProvider.addSipListener(this);
+            shootmeProvider.addSipListener(this);
+
+
+            this.proxy = new Proxy(5070, getRiProtocolObjects());
+            SipProvider provider = proxy.createSipProvider();
+            provider.setAutomaticDialogSupportEnabled(false);
+            providerTable.put(provider, proxy);
+            provider.addSipListener(this);
+
+            getTiProtocolObjects().start();
+            if (getTiProtocolObjects() != getRiProtocolObjects())
+                getRiProtocolObjects().start();
+        } catch (Exception ex) {
+            fail("unexpected exception ");
+        }
+    }
+
+
+    public void tearDown() {
+        try {
+            Thread.sleep(4000);
+            this.shootist.checkState();
+            this.shootme.checkState();
+            this.proxy.checkState();
+            getTiProtocolObjects().destroy();
+            if (getRiProtocolObjects() != getTiProtocolObjects())
+                getRiProtocolObjects().destroy();
+            Thread.sleep(2000);
+            this.providerTable.clear();
+
+            super.logTestCompleted();
+        } catch (Exception ex) {
+            logger.error("unexpected exception", ex);
+            fail("unexpected exception ");
+        }
+    }
+
+
+
+}

--- a/src/test/unit/gov/nist/javax/sip/stack/forkedinviteloopdisabled/ForkedInviteTest.java
+++ b/src/test/unit/gov/nist/javax/sip/stack/forkedinviteloopdisabled/ForkedInviteTest.java
@@ -1,0 +1,20 @@
+package test.unit.gov.nist.javax.sip.stack.forkedinviteloopdisabled;
+
+public class ForkedInviteTest extends AbstractForkedInviteTestCase {
+    boolean myFlag;
+
+    public void setUp() {
+        super.testedImplFlag = !myFlag;
+        myFlag = !super.testedImplFlag;
+        super.transport = "udp";
+        super.setUp();
+    }
+
+    public void testForkedInvite() {
+        this.shootist.sendInvite();
+    }
+    
+   
+
+
+}

--- a/src/test/unit/gov/nist/javax/sip/stack/forkedinviteloopdisabled/Proxy.java
+++ b/src/test/unit/gov/nist/javax/sip/stack/forkedinviteloopdisabled/Proxy.java
@@ -1,0 +1,245 @@
+package test.unit.gov.nist.javax.sip.stack.forkedinviteloopdisabled;
+
+import java.util.HashSet;
+import java.util.Hashtable;
+import java.util.Iterator;
+
+import javax.sip.ClientTransaction;
+import javax.sip.DialogTerminatedEvent;
+import javax.sip.IOExceptionEvent;
+import javax.sip.ListeningPoint;
+import javax.sip.RequestEvent;
+import javax.sip.ResponseEvent;
+import javax.sip.ServerTransaction;
+import javax.sip.SipListener;
+import javax.sip.SipProvider;
+import javax.sip.TimeoutEvent;
+import javax.sip.Transaction;
+import javax.sip.TransactionTerminatedEvent;
+import javax.sip.address.Address;
+import javax.sip.address.SipURI;
+import javax.sip.header.CSeqHeader;
+import javax.sip.header.RecordRouteHeader;
+import javax.sip.header.RouteHeader;
+import javax.sip.header.ViaHeader;
+import javax.sip.message.Request;
+import javax.sip.message.Response;
+
+import org.apache.log4j.Logger;
+
+import test.tck.TestHarness;
+import test.tck.msgflow.callflows.ProtocolObjects;
+
+/**
+ * A very simple forking proxy server.
+ * 
+ * @author M. Ranganathan
+ * 
+ */
+public class Proxy extends TestHarness implements SipListener {
+
+    // private ServerTransaction st;
+
+    private SipProvider inviteServerTxProvider;
+
+    private HashSet clientTxTable = new HashSet<ClientTransaction>();
+
+    private static String host = "127.0.0.1";
+
+    private int port = 5070;
+
+    private SipProvider sipProvider;
+
+    private static String unexpectedException = "Unexpected exception";
+
+    private static Logger logger = Logger.getLogger(Proxy.class);
+
+    private ProtocolObjects protocolObjects;
+
+    private boolean loopDetectedSeen;
+
+    public void processRequest(RequestEvent requestEvent) {
+        try {
+            Request request = requestEvent.getRequest();
+            SipProvider sipProvider = (SipProvider) requestEvent.getSource();
+            this.inviteServerTxProvider = sipProvider;
+            if (request.getMethod().equals(Request.INVITE)) {
+
+                ListeningPoint lp = sipProvider.getListeningPoint(protocolObjects.transport);
+                String host = lp.getIPAddress();
+                int port = lp.getPort();
+
+                ServerTransaction st = null;
+                if (requestEvent.getServerTransaction() == null) {
+                    st = sipProvider.getNewServerTransaction(request);
+
+                    Request newRequest = (Request) request.clone();
+                    SipURI sipUri = protocolObjects.addressFactory.createSipURI("UA1",
+                            "127.0.0.1");
+                    sipUri.setPort(5080);
+                    sipUri.setLrParam();
+                    Address address = protocolObjects.addressFactory.createAddress("client1",
+                            sipUri);
+                    RouteHeader rheader = protocolObjects.headerFactory
+                            .createRouteHeader(address);
+
+                    newRequest.addFirst(rheader);
+                    ViaHeader viaHeader = protocolObjects.headerFactory.createViaHeader(host,
+                            port, protocolObjects.transport, null);
+                    newRequest.addFirst(viaHeader);
+                    
+                    ClientTransaction ct1 = sipProvider.getNewClientTransaction(newRequest);
+                    sipUri = protocolObjects.addressFactory.createSipURI("proxy", "127.0.0.1");
+                    address = protocolObjects.addressFactory.createAddress("proxy", sipUri);
+                    sipUri.setPort(5080);
+                    sipUri.setLrParam();
+                    RecordRouteHeader recordRoute = protocolObjects.headerFactory
+                            .createRecordRouteHeader(address);
+                    newRequest.addHeader(recordRoute);
+                    ct1.setApplicationData(st);
+                    this.clientTxTable.add(ct1);
+
+                    newRequest = (Request) request.clone();
+                    sipUri = protocolObjects.addressFactory.createSipURI("UA2", "127.0.0.1");
+                    sipUri.setLrParam();
+                    sipUri.setPort(5080);
+                    address = protocolObjects.addressFactory.createAddress("client2", sipUri);
+                    rheader = protocolObjects.headerFactory.createRouteHeader(address);
+                    newRequest.addFirst(rheader);
+                    viaHeader = protocolObjects.headerFactory.createViaHeader(host, port,
+                            protocolObjects.transport, null);
+                    newRequest.addFirst(viaHeader);
+                    sipUri = protocolObjects.addressFactory.createSipURI("proxy", "127.0.0.1");
+                    sipUri.setPort(5080);
+                    sipUri.setLrParam();
+                    sipUri.setTransportParam(protocolObjects.transport);
+                    address = protocolObjects.addressFactory.createAddress("proxy", sipUri);
+
+                    recordRoute = protocolObjects.headerFactory.createRecordRouteHeader(address);
+
+                    newRequest.addHeader(recordRoute);
+                    ClientTransaction ct2 = sipProvider.getNewClientTransaction(newRequest);
+                    ct2.setApplicationData(st);
+                    this.clientTxTable.add(ct2);
+
+                    // Send the requests out to the two listening points of the
+                    // client.
+
+                    ct2.sendRequest();
+                    Thread.sleep((int) ( Math.abs((Math.random() * 1000 ))));
+                    
+                    ct1.sendRequest();
+                }
+
+            } else {
+                // Remove the topmost route header
+                // The route header will make sure it gets to the right place.
+                logger.info("proxy: Got a request " + request.getMethod());
+                Request newRequest = (Request) request.clone();
+                newRequest.removeFirst(RouteHeader.NAME);
+                sipProvider.sendRequest(newRequest);
+            }
+
+        } catch (Exception ex) {
+            ex.printStackTrace();
+            System.exit(0);
+        }
+
+    }
+
+    public void checkState() {
+        assertFalse("Should see not LOOP DETECTED", loopDetectedSeen);
+    }
+
+    public synchronized void processResponse(ResponseEvent responseEvent) {
+        try {
+            Response response = responseEvent.getResponse();
+            CSeqHeader cseq = (CSeqHeader) response.getHeader(CSeqHeader.NAME);
+            logger.info("ClientTxID = " + responseEvent.getClientTransaction() + " client tx id "
+                    + ((ViaHeader) response.getHeader(ViaHeader.NAME)).getBranch()
+                    + " CSeq header = " + response.getHeader(CSeqHeader.NAME) + " status code = "
+                    + response.getStatusCode());
+
+            // JvB: stateful proxy MUST NOT forward 100 Trying
+            if (response.getStatusCode() == 100)
+                return;
+
+            if (response.getStatusCode() == Response.LOOP_DETECTED) {
+            	logger.info("Saw a LOOP DETECTED response");
+                this.loopDetectedSeen = true;
+            }
+            if (cseq.getMethod().equals(Request.INVITE)) {
+                ClientTransaction ct = responseEvent.getClientTransaction();
+                if (ct != null) {
+                    ServerTransaction st = (ServerTransaction) ct.getApplicationData();
+
+                    // Strip the topmost via header
+                    Response newResponse = (Response) response.clone();
+                    newResponse.removeFirst(ViaHeader.NAME);
+                    // The server tx goes to the terminated state.
+
+                    st.sendResponse(newResponse);
+
+                } else {
+                    logger.debug("Discarding response - no transaction found!");
+                }
+            } else {
+                // this is the OK for the cancel.
+                logger.info("Got a non-invite response " + response);
+            }
+        } catch (Exception ex) {
+            ex.printStackTrace();
+            fail("unexpected exception");
+        }
+    }
+
+    public void processTimeout(TimeoutEvent timeoutEvent) {
+        logger.error("Timeout occured");
+        fail("unexpected event");
+    }
+
+    public void processIOException(IOExceptionEvent exceptionEvent) {
+        logger.info("IOException occured");
+        fail("unexpected exception io exception");
+    }
+
+    public SipProvider createSipProvider() {
+        try {
+            ListeningPoint listeningPoint = protocolObjects.sipStack.createListeningPoint(host,
+                    port, protocolObjects.transport);
+
+            sipProvider = protocolObjects.sipStack.createSipProvider(listeningPoint);
+            sipProvider.setAutomaticDialogSupportEnabled(false);
+            return sipProvider;
+        } catch (Exception ex) {
+            logger.error(unexpectedException, ex);
+            fail(unexpectedException);
+            return null;
+        }
+
+    }
+
+    public void processTransactionTerminated(TransactionTerminatedEvent transactionTerminatedEvent) {
+        logger.info("Transaction terminated event occured -- cleaning up");
+        if (!transactionTerminatedEvent.isServerTransaction()) {
+            ClientTransaction ct = transactionTerminatedEvent.getClientTransaction();
+            for (Iterator it = this.clientTxTable.iterator(); it.hasNext();) {
+                if (it.next().equals(ct)) {
+                    it.remove();
+                }
+            }
+        } else {
+            logger.info("Server tx terminated! ");
+        }
+    }
+
+    public void processDialogTerminated(DialogTerminatedEvent dialogTerminatedEvent) {
+        fail("unexpected event");
+    }
+
+    public Proxy(int myPort, ProtocolObjects protocolObjects) {
+        this.port = myPort;
+        this.protocolObjects = protocolObjects;
+    }
+
+}

--- a/src/test/unit/gov/nist/javax/sip/stack/forkedinviteloopdisabled/Shootist.java
+++ b/src/test/unit/gov/nist/javax/sip/stack/forkedinviteloopdisabled/Shootist.java
@@ -1,0 +1,389 @@
+package test.unit.gov.nist.javax.sip.stack.forkedinviteloopdisabled;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Timer;
+import java.util.TimerTask;
+
+import javax.sip.ClientTransaction;
+import javax.sip.Dialog;
+import javax.sip.DialogState;
+import javax.sip.DialogTerminatedEvent;
+import javax.sip.IOExceptionEvent;
+import javax.sip.ListeningPoint;
+import javax.sip.RequestEvent;
+import javax.sip.ResponseEvent;
+import javax.sip.ServerTransaction;
+import javax.sip.SipListener;
+import javax.sip.SipProvider;
+import javax.sip.TransactionTerminatedEvent;
+import javax.sip.address.Address;
+import javax.sip.address.SipURI;
+import javax.sip.header.CSeqHeader;
+import javax.sip.header.CallIdHeader;
+import javax.sip.header.ContactHeader;
+import javax.sip.header.ContentTypeHeader;
+import javax.sip.header.FromHeader;
+import javax.sip.header.Header;
+import javax.sip.header.MaxForwardsHeader;
+import javax.sip.header.RouteHeader;
+import javax.sip.header.ToHeader;
+import javax.sip.header.ViaHeader;
+import javax.sip.message.Request;
+import javax.sip.message.Response;
+
+import org.apache.log4j.Logger;
+
+import test.tck.TestHarness;
+import test.tck.msgflow.callflows.ProtocolObjects;
+
+/**
+ * This class is a UAC template. Shootist is the guy that shoots and shootme is the guy that gets
+ * shot.
+ * 
+ * @author M. Ranganathan
+ */
+
+public class Shootist implements SipListener {
+
+    private ContactHeader contactHeader;
+
+    private ClientTransaction inviteTid;
+
+    private SipProvider sipProvider;
+
+    private String host = "127.0.0.1";
+
+    private int port;
+
+    private String peerHost = "127.0.0.1";
+
+    private int peerPort;
+
+    private ListeningPoint listeningPoint;
+
+    private static String unexpectedException = "Unexpected exception ";
+
+    private static Logger logger = Logger.getLogger(Shootist.class);
+
+    private ProtocolObjects protocolObjects;
+
+    private Dialog originalDialog;
+
+    private HashSet forkedDialogs;
+
+    private Dialog ackedDialog;
+
+    private static Timer timer = new Timer();
+
+    private Shootist() {
+        this.forkedDialogs = new HashSet();
+    }
+
+    class AckSender extends TimerTask {
+
+        private Dialog dialog;
+        private Request ackRequest;
+
+        public AckSender(Request ackRequest, Dialog dialog) {
+            this.dialog = dialog;
+            this.ackRequest = ackRequest;
+        }
+
+        @Override
+        public void run() {
+            try {
+                logger.info("Sending ACK");
+                dialog.sendAck(ackRequest);
+                TestHarness.assertTrue("Dialog state should be CONFIRMED",
+                dialog.getState() == DialogState.CONFIRMED);
+                Shootist.this.ackedDialog = dialog;
+            } catch (Exception ex) {
+                logger.error("Unepxected exception ", ex);
+            }
+        }
+        public void sendAck() {
+            timer.schedule(this, (int)(100 * Math.abs(Math.random())) );
+        }
+
+    }
+
+    public Shootist(int myPort, int proxyPort, ProtocolObjects protocolObjects) {
+        this();
+        this.protocolObjects = protocolObjects;
+        this.port = myPort;
+        this.peerPort = proxyPort;
+
+        protocolObjects.logLevel = 32; // JvB
+    }
+
+    public void processRequest(RequestEvent requestReceivedEvent) {
+        Request request = requestReceivedEvent.getRequest();
+        ServerTransaction serverTransactionId = requestReceivedEvent.getServerTransaction();
+
+        logger.info("\n\nRequest " + request.getMethod() + " received at "
+                + protocolObjects.sipStack.getStackName() + " with server transaction id "
+                + serverTransactionId);
+
+        // We are the UAC so the only request we get is the BYE.
+        if (request.getMethod().equals(Request.BYE))
+            processBye(request, serverTransactionId);
+        else
+            TestHarness.fail("Unexpected request ! : " + request);
+
+    }
+
+    public void processBye(Request request, ServerTransaction serverTransactionId) {
+        try {
+            logger.info("shootist:  got a bye .");
+            if (serverTransactionId == null) {
+                logger.info("shootist:  null TID.");
+                return;
+            }
+            Dialog dialog = serverTransactionId.getDialog();
+            logger.info("Dialog State = " + dialog.getState());
+            Response response = protocolObjects.messageFactory.createResponse(200, request);
+            serverTransactionId.sendResponse(response);
+            logger.info("shootist:  Sending OK.");
+            logger.info("Dialog State = " + dialog.getState());
+
+        } catch (Exception ex) {
+            ex.printStackTrace();
+            System.exit(0);
+
+        }
+    }
+
+    public synchronized void processResponse(ResponseEvent responseReceivedEvent) {
+        logger.info("Got a response");
+        Response response = (Response) responseReceivedEvent.getResponse();
+        ClientTransaction tid = responseReceivedEvent.getClientTransaction();
+        CSeqHeader cseq = (CSeqHeader) response.getHeader(CSeqHeader.NAME);
+
+        logger.info("Response received : Status Code = " + response.getStatusCode() + " " + cseq);
+        logger.info("Response = " + response + " class=" + response.getClass());
+
+        Dialog dialog = responseReceivedEvent.getDialog();
+        TestHarness.assertNotNull(dialog);
+
+        if (tid != null)
+            logger.info("transaction state is " + tid.getState());
+        else
+            logger.info("transaction = " + tid);
+
+        logger.info("Dialog = " + dialog);
+
+        logger.info("Dialog state is " + dialog.getState());
+
+        try {
+            if (response.getStatusCode() == Response.OK) {
+                if (cseq.getMethod().equals(Request.INVITE)) {
+                    TestHarness.assertEquals(DialogState.CONFIRMED, dialog.getState());
+                    Request ackRequest = dialog.createAck(cseq.getSeqNumber());
+
+                    TestHarness.assertNotNull(ackRequest.getHeader(MaxForwardsHeader.NAME));
+
+                    if (dialog == this.ackedDialog) {
+                        dialog.sendAck(ackRequest);
+                        return;
+                    }
+                    this.forkedDialogs.add(dialog);
+
+                    new AckSender(ackRequest, dialog).sendAck();
+
+                } else {
+                    logger.info("Response method = " + cseq.getMethod());
+                }
+            } else if (response.getStatusCode() == Response.RINGING) {
+                // TestHarness.assertEquals( DialogState.EARLY, dialog.getState() );
+            }
+        } catch (Throwable ex) {
+            ex.printStackTrace();
+            // System.exit(0);
+        }
+
+    }
+
+    public SipProvider createSipProvider() {
+        try {
+            listeningPoint = protocolObjects.sipStack.createListeningPoint(host, port,
+                    protocolObjects.transport);
+
+            logger.info("listening point = " + host + " port = " + port);
+            logger.info("listening point = " + listeningPoint);
+            sipProvider = protocolObjects.sipStack.createSipProvider(listeningPoint);
+            return sipProvider;
+        } catch (Exception ex) {
+            logger.error(unexpectedException, ex);
+            TestHarness.fail(unexpectedException);
+            return null;
+        }
+
+    }
+
+    public void checkState() {
+        TestHarness.assertTrue("Should see at two dialogs", this.forkedDialogs.size() == 2);
+
+        // cleanup
+        forkedDialogs.clear();
+    }
+
+    public void processTimeout(javax.sip.TimeoutEvent timeoutEvent) {
+
+        logger.info("Transaction Time out");
+    }
+
+    public void sendInvite() {
+        try {
+
+            String fromName = "BigGuy";
+            String fromSipAddress = "here.com";
+            String fromDisplayName = "The Master Blaster";
+
+            String toSipAddress = "there.com";
+            String toUser = "LittleGuy";
+            String toDisplayName = "The Little Blister";
+
+            // create >From Header
+            SipURI fromAddress = protocolObjects.addressFactory.createSipURI(fromName,
+                    fromSipAddress);
+
+            Address fromNameAddress = protocolObjects.addressFactory.createAddress(fromAddress);
+            fromNameAddress.setDisplayName(fromDisplayName);
+            FromHeader fromHeader = protocolObjects.headerFactory.createFromHeader(
+                    fromNameAddress, "12345");
+
+            // create To Header
+            SipURI toAddress = protocolObjects.addressFactory.createSipURI(toUser, toSipAddress);
+            Address toNameAddress = protocolObjects.addressFactory.createAddress(toAddress);
+            toNameAddress.setDisplayName(toDisplayName);
+            ToHeader toHeader = protocolObjects.headerFactory.createToHeader(toNameAddress, null);
+
+            // create Request URI
+            String peerHostPort = peerHost + ":" + peerPort;
+            SipURI requestURI = protocolObjects.addressFactory.createSipURI(toUser, peerHostPort);
+
+            // Create ViaHeaders
+
+            ArrayList viaHeaders = new ArrayList();
+            ViaHeader viaHeader = protocolObjects.headerFactory.createViaHeader(host, sipProvider
+                    .getListeningPoint(protocolObjects.transport).getPort(),
+                    protocolObjects.transport, null);
+
+            // add via headers
+            viaHeaders.add(viaHeader);
+
+            SipURI sipuri = protocolObjects.addressFactory.createSipURI(null, host);
+            sipuri.setPort(peerPort);
+            sipuri.setLrParam();
+
+            RouteHeader routeHeader = protocolObjects.headerFactory
+                    .createRouteHeader(protocolObjects.addressFactory.createAddress(sipuri));
+
+            // Create ContentTypeHeader
+            ContentTypeHeader contentTypeHeader = protocolObjects.headerFactory
+                    .createContentTypeHeader("application", "sdp");
+
+            // Create a new CallId header
+            CallIdHeader callIdHeader = sipProvider.getNewCallId();
+            // JvB: Make sure that the implementation matches the messagefactory
+            callIdHeader = protocolObjects.headerFactory.createCallIdHeader(callIdHeader
+                    .getCallId());
+
+            // Create a new Cseq header
+            CSeqHeader cSeqHeader = protocolObjects.headerFactory.createCSeqHeader(1L,
+                    Request.INVITE);
+
+            // Create a new MaxForwardsHeader
+            MaxForwardsHeader maxForwards = protocolObjects.headerFactory
+                    .createMaxForwardsHeader(70);
+
+            // Create the request.
+            Request request = protocolObjects.messageFactory.createRequest(requestURI,
+                    Request.INVITE, callIdHeader, cSeqHeader, fromHeader, toHeader, viaHeaders,
+                    maxForwards);
+            // Create contact headers
+
+            SipURI contactUrl = protocolObjects.addressFactory.createSipURI(fromName, host);
+            contactUrl.setPort(listeningPoint.getPort());
+
+            // Create the contact name address.
+            SipURI contactURI = protocolObjects.addressFactory.createSipURI(fromName, host);
+            contactURI
+                    .setPort(sipProvider.getListeningPoint(protocolObjects.transport).getPort());
+            contactURI.setTransportParam(protocolObjects.transport);
+
+            Address contactAddress = protocolObjects.addressFactory.createAddress(contactURI);
+
+            // Add the contact address.
+            contactAddress.setDisplayName(fromName);
+
+            contactHeader = protocolObjects.headerFactory.createContactHeader(contactAddress);
+            request.addHeader(contactHeader);
+
+            // Dont use the Outbound Proxy. Use Lr instead.
+            request.setHeader(routeHeader);
+
+            // Add the extension header.
+            Header extensionHeader = protocolObjects.headerFactory.createHeader("My-Header",
+                    "my header value");
+            request.addHeader(extensionHeader);
+
+            String sdpData = "v=0\r\n" + "o=4855 13760799956958020 13760799956958020"
+                    + " IN IP4  129.6.55.78\r\n" + "s=mysession session\r\n"
+                    + "p=+46 8 52018010\r\n" + "c=IN IP4  129.6.55.78\r\n" + "t=0 0\r\n"
+                    + "m=audio 6022 RTP/AVP 0 4 18\r\n" + "a=rtpmap:0 PCMU/8000\r\n"
+                    + "a=rtpmap:4 G723/8000\r\n" + "a=rtpmap:18 G729A/8000\r\n"
+                    + "a=ptime:20\r\n";
+            byte[] contents = sdpData.getBytes();
+
+            request.setContent(contents, contentTypeHeader);
+
+            extensionHeader = protocolObjects.headerFactory.createHeader("My-Other-Header",
+                    "my new header value ");
+            request.addHeader(extensionHeader);
+
+            Header callInfoHeader = protocolObjects.headerFactory.createHeader("Call-Info",
+                    "<http://www.antd.nist.gov>");
+            request.addHeader(callInfoHeader);
+
+            // Create the client transaction.
+            inviteTid = sipProvider.getNewClientTransaction(request);
+            Dialog dialog = inviteTid.getDialog();
+
+            TestHarness.assertTrue("Initial dialog state should be null",
+                    dialog.getState() == null);
+
+            // send the request out.
+            inviteTid.sendRequest();
+
+            this.originalDialog = dialog;
+            // This is not a valid test. There is a race condition in this test
+            // the response may have already come in and reset the state of the tx
+            // to proceeding.
+            // TestHarness.assertSame(
+            // "Initial transaction state should be CALLING", inviteTid
+            // .getState(), TransactionState.CALLING);
+
+        } catch (Exception ex) {
+            logger.error(unexpectedException, ex);
+            TestHarness.fail(unexpectedException);
+
+        }
+    }
+
+    public void processIOException(IOExceptionEvent exceptionEvent) {
+        logger.info("IOException happened for " + exceptionEvent.getHost() + " port = "
+                + exceptionEvent.getPort());
+
+    }
+
+    public void processTransactionTerminated(TransactionTerminatedEvent transactionTerminatedEvent) {
+        logger.info("Transaction terminated event recieved");
+    }
+
+    public void processDialogTerminated(DialogTerminatedEvent dialogTerminatedEvent) {
+        logger.info("dialogTerminatedEvent");
+
+    }
+}

--- a/src/test/unit/gov/nist/javax/sip/stack/forkedinviteloopdisabled/Shootme.java
+++ b/src/test/unit/gov/nist/javax/sip/stack/forkedinviteloopdisabled/Shootme.java
@@ -1,0 +1,337 @@
+package test.unit.gov.nist.javax.sip.stack.forkedinviteloopdisabled;
+
+import javax.sip.*;
+import javax.sip.address.*;
+import javax.sip.header.*;
+import javax.sip.message.*;
+
+import org.apache.log4j.ConsoleAppender;
+import org.apache.log4j.Logger;
+import org.apache.log4j.SimpleLayout;
+
+import gov.nist.javax.sip.SipProviderExt;
+import test.tck.TestHarness;
+import test.tck.msgflow.callflows.ProtocolObjects;
+
+
+
+import java.util.*;
+
+import junit.framework.TestCase;
+
+/**
+ * This class is a UAC template. Shootist is the guy that shoots and shootme is
+ * the guy that gets shot.
+ *
+ * @author M. Ranganathan
+ */
+
+public class Shootme   implements SipListener {
+
+
+
+
+    private static final String myAddress = "127.0.0.1";
+
+    private Hashtable serverTxTable = new Hashtable();
+
+    private SipProvider sipProvider;
+
+    private int myPort ;
+
+    private static String unexpectedException = "Unexpected exception ";
+
+    private static Logger logger = Logger.getLogger(Shootme.class);
+
+    private ProtocolObjects protocolObjects;
+
+
+    private boolean inviteSeen;
+
+
+    private boolean byeSeen;
+
+    private boolean ackSeen;
+
+    private boolean actAsNonRFC3261UAS;
+
+    /**
+     * Causes this UAS to act as a non-RFC3261 UAS, i.e. does not set a to-tag
+     */
+    public void setNonRFC3261( boolean b ) {
+        this.actAsNonRFC3261UAS = b;
+    }
+
+    class MyTimerTask extends TimerTask {
+        RequestEvent  requestEvent;
+        // String toTag;
+        ServerTransaction serverTx;
+
+        public MyTimerTask(RequestEvent requestEvent,ServerTransaction tx) {
+            logger.info("MyTimerTask ");
+            this.requestEvent = requestEvent;
+            // this.toTag = toTag;
+            this.serverTx = tx;
+
+        }
+
+        public void run() {
+            sendInviteOK(requestEvent,serverTx);
+        }
+
+    }
+
+
+
+    public void processRequest(RequestEvent requestEvent) {
+        Request request = requestEvent.getRequest();
+        ServerTransaction serverTransactionId = requestEvent
+                .getServerTransaction();
+
+        logger.info("\n\nRequest " + request.getMethod()
+                + " received at " + protocolObjects.sipStack.getStackName()
+                + " with server transaction id " + serverTransactionId);
+
+        if (request.getMethod().equals(Request.INVITE)) {
+            processInvite(requestEvent, serverTransactionId);
+        } else if (request.getMethod().equals(Request.ACK)) {
+            processAck(requestEvent, serverTransactionId);
+        } else if (request.getMethod().equals(Request.BYE)) {
+            processBye(requestEvent, serverTransactionId);
+        } else if (request.getMethod().equals(Request.CANCEL)) {
+            processCancel(requestEvent, serverTransactionId);
+        }
+
+    }
+
+    public void processResponse(ResponseEvent responseEvent) {
+    }
+
+    /**
+     * Process the ACK request. Send the bye and complete the call flow.
+     */
+    public void processAck(RequestEvent requestEvent,
+            ServerTransaction serverTransaction) {
+        logger.info("shootme: got an ACK! ");
+        logger.info("Dialog = " + requestEvent.getDialog());
+        if ( requestEvent.getDialog() != null ) {
+            logger.info("Dialog State = " + requestEvent.getDialog().getState());
+        } else {
+            logger.debug("No dialog !!");
+        }
+
+        this.ackSeen = true;
+    }
+
+    /**
+     * Process the invite request.
+     */
+    public void processInvite(RequestEvent requestEvent,
+            ServerTransaction serverTransaction) {
+        SipProvider sipProvider = (SipProvider) requestEvent.getSource();
+        Request request = requestEvent.getRequest();
+        try {
+            logger.info("shootme: got an Invite sending Trying");
+            // logger.info("shootme: " + request);
+
+            ServerTransaction st = requestEvent.getServerTransaction();
+
+            if (st == null) {
+                logger.info("null server tx -- getting a new one");
+                st = sipProvider.getNewServerTransaction(request);
+            }
+
+            logger.info("getNewServerTransaction : " + st);
+
+            String txId = ((ViaHeader)request.getHeader(ViaHeader.NAME)).getBranch();
+            this.serverTxTable.put(txId, st);
+
+            // Create the 100 Trying response.
+            Response response = protocolObjects.messageFactory.createResponse(Response.TRYING,
+                    request);
+                ListeningPoint lp = sipProvider.getListeningPoint(protocolObjects.transport);
+            int myPort = lp.getPort();
+
+            Address address = protocolObjects.addressFactory.createAddress("Shootme <sip:"
+                    + myAddress + ":" + myPort + ">");
+
+            // Add a random sleep to stagger the two OK's for the benifit of implementations
+            // that may not be too good about handling re-entrancy.
+            int timeToSleep = (int) ( Math.random() * 1000);
+
+            Thread.sleep(timeToSleep);
+
+            st.sendResponse(response);
+
+            Response ringingResponse = protocolObjects.messageFactory.createResponse(Response.RINGING,
+                    request);
+            ContactHeader contactHeader = protocolObjects.headerFactory.createContactHeader(address);
+            response.addHeader(contactHeader);
+            ToHeader toHeader = (ToHeader) ringingResponse.getHeader(ToHeader.NAME);
+            String toTag = actAsNonRFC3261UAS ? null : new Integer((int) (Math.random() * 10000)).toString();
+            if (!actAsNonRFC3261UAS) toHeader.setTag(toTag); // Application is supposed to set.
+            ringingResponse.addHeader(contactHeader);
+            st.sendResponse(ringingResponse);
+            Dialog dialog =  st.getDialog();
+            dialog.setApplicationData(st);
+
+            this.inviteSeen = true;
+
+            new Timer().schedule(new MyTimerTask(requestEvent,st/*,toTag*/), 1000);
+        } catch (Exception ex) {
+            ex.printStackTrace();
+            System.exit(0);
+        }
+    }
+
+    private void sendInviteOK(RequestEvent requestEvent, ServerTransaction inviteTid) {
+        try {
+            logger.info("sendInviteOK: " + inviteTid);
+            if (inviteTid.getState() != TransactionState.COMPLETED) {
+                logger.info("shootme: Dialog state before OK: "
+                        + inviteTid.getDialog().getState());
+
+                SipProvider sipProvider = (SipProvider) requestEvent.getSource();
+                Request request = requestEvent.getRequest();
+                Response okResponse = protocolObjects.messageFactory.createResponse(Response.OK,
+                        request);
+                    ListeningPoint lp = sipProvider.getListeningPoint(protocolObjects.transport);
+                int myPort = lp.getPort();
+
+                Address address = protocolObjects.addressFactory.createAddress("Shootme <sip:"
+                        + myAddress + ":" + myPort + ">");
+                ContactHeader contactHeader = protocolObjects.headerFactory
+                        .createContactHeader(address);
+                okResponse.addHeader(contactHeader);
+                inviteTid.sendResponse(okResponse);
+                logger.info("shootme: Dialog state after OK: "
+                        + inviteTid.getDialog().getState());
+                TestHarness.assertEquals( DialogState.CONFIRMED , inviteTid.getDialog().getState() );
+            } else {
+                logger.info("semdInviteOK: inviteTid = " + inviteTid + " state = " + inviteTid.getState());
+            }
+        } catch (Exception ex) {
+            ex.printStackTrace();
+        }
+    }
+
+    /**
+     * Process the bye request.
+     */
+    public void processBye(RequestEvent requestEvent,
+            ServerTransaction serverTransactionId) {
+        Request request = requestEvent.getRequest();
+        try {
+            logger.info("shootme:  got a bye sending OK.");
+            logger.info("shootme:  dialog = " + requestEvent.getDialog());
+            logger.info("shootme:  dialogState = " + requestEvent.getDialog().getState());
+            Response response = protocolObjects.messageFactory.createResponse(200, request);
+            if ( serverTransactionId != null) {
+                serverTransactionId.sendResponse(response);
+            }
+            logger.info("shootme:  dialogState = " + requestEvent.getDialog().getState());
+
+            this.byeSeen = true;
+
+
+        } catch (Exception ex) {
+            ex.printStackTrace();
+            System.exit(0);
+
+        }
+    }
+
+    public void processCancel(RequestEvent requestEvent,
+            ServerTransaction serverTransactionId) {
+        Request request = requestEvent.getRequest();
+        SipProvider sipProvider = (SipProvider)requestEvent.getSource();
+        try {
+            logger.info("shootme:  got a cancel. " );
+            // Because this is not an In-dialog request, you will get a null server Tx id here.
+            if (serverTransactionId == null) {
+                serverTransactionId = sipProvider.getNewServerTransaction(request);
+            }
+            Response response = protocolObjects.messageFactory.createResponse(200, request);
+            serverTransactionId.sendResponse(response);
+
+            String serverTxId = ((ViaHeader)response.getHeader(ViaHeader.NAME)).getBranch();
+            ServerTransaction serverTx = (ServerTransaction) this.serverTxTable.get(serverTxId);
+            if ( serverTx != null && (serverTx.getState().equals(TransactionState.TRYING) ||
+                    serverTx.getState().equals(TransactionState.PROCEEDING))) {
+                Request originalRequest = serverTx.getRequest();
+                Response resp = protocolObjects.messageFactory.createResponse(Response.REQUEST_TERMINATED,originalRequest);
+                serverTx.sendResponse(resp);
+            }
+
+        } catch (Exception ex) {
+            ex.printStackTrace();
+            System.exit(0);
+
+        }
+    }
+
+    public void processTimeout(javax.sip.TimeoutEvent timeoutEvent) {
+        Transaction transaction;
+        if (timeoutEvent.isServerTransaction()) {
+            transaction = timeoutEvent.getServerTransaction();
+        } else {
+            transaction = timeoutEvent.getClientTransaction();
+        }
+        logger.info("state = " + transaction.getState());
+        logger.info("dialog = " + transaction.getDialog());
+        logger.info("dialogState = "
+                + transaction.getDialog().getState());
+        logger.info("Transaction Time out");
+    }
+
+    public SipProvider createProvider() {
+        try {
+
+            ListeningPoint lp = protocolObjects.sipStack.createListeningPoint(myAddress,
+                    myPort, protocolObjects.transport);
+
+            sipProvider = protocolObjects.sipStack.createSipProvider(lp);
+            logger.info("provider " + sipProvider);
+            logger.info("sipStack = " + protocolObjects.sipStack);
+            sipProvider.setAutomaticDialogSupportEnabled(true);
+            ((SipProviderExt) sipProvider).setLoopDetectionEnabled(false);
+            return sipProvider;
+        } catch (Exception ex) {
+            logger.error(ex);
+            TestHarness.fail(unexpectedException);
+            return null;
+
+        }
+
+    }
+
+    public Shootme( int myPort, ProtocolObjects protocolObjects ) {
+        this.myPort = myPort;
+        this.protocolObjects = protocolObjects;
+    }
+
+
+
+    public void processIOException(IOExceptionEvent exceptionEvent) {
+        logger.info("IOException");
+
+    }
+
+    public void processTransactionTerminated(
+            TransactionTerminatedEvent transactionTerminatedEvent) {
+        logger.info("Transaction terminated event recieved");
+
+    }
+
+    public void processDialogTerminated(
+            DialogTerminatedEvent dialogTerminatedEvent) {
+        logger.info("Dialog terminated event recieved");
+
+    }
+
+    public void checkState() {
+        TestHarness.assertTrue("Should see invite", inviteSeen);
+
+    }
+
+}


### PR DESCRIPTION
We currently have an application using the Jain SIP which is a UAS acting as a redirect server. Within our infrastructure, due to the redundancy model, it is possible for the same INVITE to be sent twice to our redirect UAS.

[Here's the flow](https://www.websequencediagrams.com/cgi-bin/cdraw?lz=dGl0bGUgTG9vcCBEZXRlY3Rpb24KCnBhcnRpY2lwYW50IEFsaWNlAAUNIlByb3h5IEEiAAIUQgAIDlJlZGlyZWN0AEYNQm9iCgoAUwUtPgBFBzogSU5WSVRFCgBVBy0-ADIIABEJAEMIACkLMzAyIE1vdmVkIFRlbXBvcmFyaWx5ADkKQm9iOgBHEACBSgU6NDA4IFJlcXVlc3QgVGltZW91dACBAw5CAIECD0IAbiNCOiA0ODIAgkcGZACCSAVlZAo&s=default)

In rfc3261 section 8.2.2.2, it says:

 "If the request has no tag in the To header field, the UAS core MUST
   check the request against ongoing transactions.  If the From tag,
   Call-ID, and CSeq exactly match those associated with an ongoing
   transaction, but the request does not match that transaction (based
   on the matching rules in Section 17.2.3), the UAS core SHOULD
   generate a 482 (Loop Detected) response and pass it to the server
   transaction."

Being optional, I propose to add a configuration which allows the disabling of the loop detection. I'm not a 100% certain on the naming of my configuration.