### PR TITLE
Avoid sending double CRLF keep alive on TCP socket shutdown

### DIFF
--- a/src/gov/nist/javax/sip/parser/NioPipelineParser.java
+++ b/src/gov/nist/javax/sip/parser/NioPipelineParser.java
@@ -297,9 +297,9 @@ public class NioPipelineParser {
                 	crlfReceived = false;
 
                 	try {
-						sipMessageListener.sendSingleCLRF();
+						sipMessageListener.sendSingleCRLF();
 					} catch (Exception e) {						
-						logger.logError("A problem occured while trying to send a single CLRF in response to a double CLRF", e);
+						logger.logError("A problem occured while trying to send a single CRLF in response to a double CRLF", e);
 					}                	                	
             	} else {
             		crlfReceived = true;

--- a/src/gov/nist/javax/sip/parser/PipelinedMsgParser.java
+++ b/src/gov/nist/javax/sip/parser/PipelinedMsgParser.java
@@ -366,9 +366,9 @@ public final class PipelinedMsgParser implements Runnable {
                                 isPreviousLineCRLF = false;
 
                             	try {
-            						sipMessageListener.sendSingleCLRF();
+            						sipMessageListener.sendSingleCRLF();
             					} catch (Exception e) {						
-            						logger.logError("A problem occured while trying to send a single CLRF in response to a double CLRF", e);
+            						logger.logError("A problem occured while trying to send a single CRLF in response to a double CRLF", e);
             					}                	
                             	continue;
                         	} else {

--- a/src/gov/nist/javax/sip/parser/SIPMessageListener.java
+++ b/src/gov/nist/javax/sip/parser/SIPMessageListener.java
@@ -45,7 +45,7 @@ public interface SIPMessageListener extends ParseExceptionListener {
      */
     public void processMessage(SIPMessage msg) throws Exception;
 
-	public void sendSingleCLRF() throws Exception;
+	public void sendSingleCRLF() throws Exception;
 }
 /*
  * $Log: not supported by cvs2svn $

--- a/src/gov/nist/javax/sip/stack/ConnectionOrientedMessageChannel.java
+++ b/src/gov/nist/javax/sip/stack/ConnectionOrientedMessageChannel.java
@@ -574,7 +574,7 @@ public abstract class ConnectionOrientedMessageChannel extends MessageChannel im
                     int nbytes = myClientInputStream.read(msg, 0, bufferSize);
                     // no more bytes to read...
                     if (nbytes == -1) {
-                        hispipe.write("\r\n\r\n".getBytes("UTF-8"));
+                        hispipe.write("\r\n".getBytes("UTF-8")); // send \r\n to allow the pipe to wake up
                         try {
                             if (sipStack.maxConnections != -1) {
                                 synchronized (messageProcessor) {

--- a/src/gov/nist/javax/sip/stack/ConnectionOrientedMessageChannel.java
+++ b/src/gov/nist/javax/sip/stack/ConnectionOrientedMessageChannel.java
@@ -694,7 +694,7 @@ public abstract class ConnectionOrientedMessageChannel extends MessageChannel im
      * (non-Javadoc)
      * @see gov.nist.javax.sip.parser.SIPMessageListener#sendSingleCLRF()
      */
-	public void sendSingleCLRF() throws Exception {
+	public void sendSingleCRLF() throws Exception {
         lastKeepAliveReceivedTime = System.currentTimeMillis();
 
 		if(mySock != null && !mySock.isClosed()) {


### PR DESCRIPTION
The current implementation does send a duplicate CRLF in the case of a TCP/TLS connection shutdown (socket closed). This leads to the situation that the PipelinedMsgParser handles it as "RFC 5626 CRLF keepalive mechanism" and tries to send a single CRLF. This sending will of course fail because the socket is closed.
Due to a race condition when closing the socket, sometimes this will lead to the error message "A problem occured while trying to send a single CRLF in response to a double CRLF" which is no error.
By the way I've fixed a small typo: "CRLF" was sometimes "CLRF" in log messages an in the code.
