### PR TITLE
Fixed race condition: SocketException due to mySock closed while sending response

### DIFF
--- a/src/gov/nist/javax/sip/stack/TCPMessageChannel.java
+++ b/src/gov/nist/javax/sip/stack/TCPMessageChannel.java
@@ -235,6 +235,9 @@ public class TCPMessageChannel extends ConnectionOrientedMessageChannel {
        
         Socket sock = null;
         IOException problem = null;
+        // try to prevent at least the worst thread safety issues by using a local variable ...
+        Socket mySockLocal = mySock;
+
         try {
         	sock = this.sipStack.ioHandler.sendBytes(this.messageProcessor.getIpAddress(),
                 this.peerAddress, this.peerPort, this.peerProtocol, msg, isClient, this);
@@ -270,8 +273,8 @@ public class TCPMessageChannel extends ConnectionOrientedMessageChannel {
         // if (mySock == null && s != null) {
         // this.uncache();
         // } else
-        if (sock != mySock && sock != null) {
-       	 if (mySock != null) {
+        if (sock != mySockLocal && sock != null) {
+            if (mySockLocal != null) {
        		 if(logger.isLoggingEnabled(LogWriter.TRACE_WARN)) {
        			 logger.logWarning(
                     		 "Old socket different than new socket on channel " + key);
@@ -288,19 +291,23 @@ public class TCPMessageChannel extends ConnectionOrientedMessageChannel {
        		 close(false, false);
        	}    
        	if(problem == null) {
-       		if(mySock != null) {
+                if (mySockLocal != null) {
 	        		if(logger.isLoggingEnabled(LogWriter.TRACE_WARN)) {
 	        			logger.logWarning(
 	                		 "There was no exception for the retry mechanism so creating a new thread based on the new socket for incoming " + key);
 	        		}
        		}
-	            mySock = sock;
-	            this.myClientInputStream = mySock.getInputStream();
-	            this.myClientOutputStream = mySock.getOutputStream();
-	            Thread thread = new Thread(this);
-	            thread.setDaemon(true);
-	            thread.setName("TCPMessageChannelThread");
-	            thread.start();
+                // NOTE: need to consider refactoring the whole socket handling with respect to thread safety
+                if (mySockLocal == mySock) {
+                    // still not thread safe :-( but what else to do?
+                    mySock = sock;
+                    this.myClientInputStream = mySock.getInputStream();
+                    this.myClientOutputStream = mySock.getOutputStream();
+                    Thread thread = new Thread(this);
+                    thread.setDaemon(true);
+                    thread.setName("TCPMessageChannelThread");
+                    thread.start();
+                }
        	} else {
        		if(logger.isLoggingEnabled(LogWriter.TRACE_WARN)) {
        			logger.logWarning(


### PR DESCRIPTION
We have a scenario where a load balancer (Linux Virtual Server - LVS) sends SIP OPTIONS every 5 seconds via TCP. 
When receiving this OPTIONS, our application (using this SIP stack) sends 200 OK and the LVS immediately closes the TCP connection after having received it.
Im some cases the socket close is very fast and comes into the TCPMessageChannel while sending the 200 OK in method _sendMessage_ is still in progress. 
Unfortunately the socket close will set the _mySock_ member to null while the _sendMessage_ method is still accessing it. 
This can happen, because the socket handling is not thread safe. 
_sendMessage_ will then run into the situation that it overwrites the _mySock_ with the current send socket _sock_ (line 297). 
In our LVS case _sock_ and _mySock_ are the same because LVS puts it's own TCP port into the Via header and no additional TCP connection needs to be established for sending the response. 
As a result accessing the overwritten mySock causes a SocketException.

My suggested fix will avoid accessing the live _mySock_ member by making a copy of it in the beginning of sendMessage and checks afterwards, if the copy is still identical to _mySock_. 
This avoids the problem we have but the socket handling is still not thread safe and needs further refactoring in the future.

[sip-race-condition.log](https://github.com/usnistgov/jsip/files/1711735/sip-race-condition.log)
