### PR TITLE
Add support for TCP_NODELAY

### DIFF
--- a/src/gov/nist/javax/sip/SipStackImpl.java
+++ b/src/gov/nist/javax/sip/SipStackImpl.java
@@ -564,8 +564,11 @@ import javax.sip.message.Request;
  * A Disabled value will not require a certificate chain for the Server Connection. A DisabledAll will not require a certificate chain for both Server and Client Connections.
  * </li>
  *
- *<li><b>gov.nist.javax.sip.RELIABLE_CONNECTION_KEEP_ALIVE_TIMEOUT</b> Value in seconds which is used as default keepalive timeout
- * (See also http://tools.ietf.org/html/rfc5626#section-4.4.1). Defaults to "infiinity" seconds (i.e. timeout event not delivered).</li>
+ * <li><b>gov.nist.javax.sip.RELIABLE_CONNECTION_KEEP_ALIVE_TIMEOUT</b> Value in seconds which is used as default keepalive timeout
+ * (See also http://tools.ietf.org/html/rfc5626#section-4.4.1). Defaults to "infinity" seconds (i.e. timeout event not delivered).</li>
+ *
+ *  <li><b>gov.nist.javax.sip.TCP_NODELAY = [true|false]</b>
+ *  Whether or not to disable Nagle's algorithm for TCP sockets. Defaults to {@code false}.</li>
  * 
  * <li><b>gov.nist.javax.sip.SSL_HANDSHAKE_TIMEOUT</b> Value in seconds which is used as default timeout for performing the SSL Handshake
  * This prevents bad clients of connecting without sending any data to block the server</li>
@@ -1102,6 +1105,12 @@ public class SipStackImpl extends SIPTransactionStack implements
 							"TCP post-parse thread pool size - bad value " + tcpTreadPoolSize + " : " + ex.getMessage());
 			}
 		}
+
+        String isTcpNoDelayEnabled = configurationProperties
+                .getProperty("gov.nist.javax.sip.TCP_NODELAY");
+        if (isTcpNoDelayEnabled != null) {
+            this.isTcpNoDelayEnabled = Boolean.parseBoolean(isTcpNoDelayEnabled);
+        }
 
 		String serverTransactionTableSize = configurationProperties
 				.getProperty("gov.nist.javax.sip.MAX_SERVER_TRANSACTIONS");

--- a/src/gov/nist/javax/sip/stack/NioTcpMessageProcessor.java
+++ b/src/gov/nist/javax/sip/stack/NioTcpMessageProcessor.java
@@ -33,6 +33,7 @@ import gov.nist.core.StackLogger;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.StandardSocketOptions;
 import java.nio.ByteBuffer;
 import java.nio.channels.*;
 import java.util.*;
@@ -237,6 +238,11 @@ public class NioTcpMessageProcessor extends ConnectionOrientedMessageProcessor {
         	 ServerSocketChannel serverSocketChannel = (ServerSocketChannel) selectionKey.channel();
         	 SocketChannel client;
         	 client = serverSocketChannel.accept();
+
+             if (sipStack.isTcpNoDelayEnabled) {
+                 client.setOption(StandardSocketOptions.TCP_NODELAY, true);
+             }
+
         	 client.configureBlocking(false);
         	 if(logger.isLoggingEnabled(LogWriter.TRACE_DEBUG))
         		 logger.logDebug("got a new connection! " + client);

--- a/src/gov/nist/javax/sip/stack/SIPTransactionStack.java
+++ b/src/gov/nist/javax/sip/stack/SIPTransactionStack.java
@@ -351,6 +351,8 @@ public abstract class SIPTransactionStack implements
     
     protected boolean isDialogTerminatedEventDeliveredForNullDialog = false;
 
+    protected boolean isTcpNoDelayEnabled = false;
+
     // Max time for a forked response to arrive. After this time, the original
     // dialog
     // is not tracked. If you want to track the original transaction you need to

--- a/src/gov/nist/javax/sip/stack/TCPMessageProcessor.java
+++ b/src/gov/nist/javax/sip/stack/TCPMessageProcessor.java
@@ -122,6 +122,11 @@ public class TCPMessageProcessor extends ConnectionOrientedMessageProcessor impl
                 }
 
                 Socket newsock = sock.accept();
+
+                if (sipStack.isTcpNoDelayEnabled) {
+                    newsock.setTcpNoDelay(true);
+                }
+
                 if (logger.isLoggingEnabled(LogWriter.TRACE_DEBUG)) {
                     logger.logDebug("Accepting new connection!");
                 }

--- a/src/gov/nist/javax/sip/stack/TLSMessageProcessor.java
+++ b/src/gov/nist/javax/sip/stack/TLSMessageProcessor.java
@@ -159,6 +159,9 @@ public class TLSMessageProcessor extends ConnectionOrientedMessageProcessor impl
                 }
                 
                 newsock = sock.accept();
+                if (sipStack.isTcpNoDelayEnabled) {
+                    newsock.setTcpNoDelay(true);
+                }
                
                 if (logger.isLoggingEnabled(LogWriter.TRACE_DEBUG)) {
                     logger.logDebug("Accepting new connection!");


### PR DESCRIPTION
New config property named `gov.nist.javax.sip.TCP_NODELAY` that when set, instructs the SipStack to create TCP sockets with the TCP_NODELAY option enabled. The option defaults to false to preserve existing functionality.