### PR TITLE
AtomicInteger object is not created for "nesting_level" instance variable 

### DIFF
--- a/src/gov/nist/core/ParserCore.java
+++ b/src/gov/nist/core/ParserCore.java
@@ -41,7 +41,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 public abstract class ParserCore {
     public static final boolean debug = Debug.parserDebug;
 
-    static AtomicInteger nesting_level;
+    static AtomicInteger nesting_level =new AtomicInteger();
 
     protected LexerCore lexer;
 


### PR DESCRIPTION
created AtomicInteger object for nesting_level instance variable