### PR TITLE
Do not use exceptions for control flow in StringTokenizer.lookAhead

### DIFF
--- a/src/gov/nist/core/StringTokenizer.java
+++ b/src/gov/nist/core/StringTokenizer.java
@@ -134,12 +134,8 @@ public class StringTokenizer {
 
     public char lookAhead(int k) throws ParseException {
         // Debug.out.println("ptr = " + ptr);
-        try {
-            return buffer[ptr + k];
-        }
-        catch (IndexOutOfBoundsException e) {
-            return '\0';
-        }
+        int index = ptr + k;
+        return index < buffer.length ? buffer[index] : '\0';
     }
 
     public char getNextChar() throws ParseException {


### PR DESCRIPTION
It's easier to check if we are out of buffer bounds and return '\0'.
Motivation:
- it's easier to debug cases when we need to set breakpoint on any
  exeception because we have a much less noise.
- theoretically it should be a little bit faster. But I'm too lazy
  to write a benchmark.