### PR TITLE
parsing correctly the second HEXDIG of a URL-encoded character

### DIFF
--- a/src/gov/nist/core/LexerCore.java
+++ b/src/gov/nist/core/LexerCore.java
@@ -702,7 +702,7 @@ public class LexerCore extends StringTokenizer {
      * Do not consume the input.
      */
     public String charAsString(int nchars) {
-        return String.valueOf(buffer, ptr, nchars -1);
+        return String.valueOf(buffer, ptr, nchars);
     }
 
     /** Get and consume the next number.

--- a/src/test/unit/gov/nist/javax/sip/parser/URLParserTest.java
+++ b/src/test/unit/gov/nist/javax/sip/parser/URLParserTest.java
@@ -68,7 +68,8 @@ public class URLParserTest extends TestCase {
           "sip:annc@10.10.30.186:6666;early=no;play=http://10.10.30.186:8080/examples/pin.vxml",
         "tel:+463-1701-4291" ,
         "tel:46317014291" ,
-        "http://10.10.30.186:8080/examples/pin.vxml"
+        "http://10.10.30.186:8080/examples/pin.vxml",
+        "http://10.10.30.186:8080/examples/%2B12125551212"
         };
 
 


### PR DESCRIPTION
Currently, when a header contains an http url having some URL-encoded character, the second HEXDIG is lost.

For example
<http://example.com/%2B1234567>
 becomes
<http://example.com/%21234567>
when parsed.

charAsString(3) is called from UrlParser (see below), it is only returning 2 chars from the buffer, but 3 are consumed.

[...]
} else if (isEscaped()) {
  String retval = lexer.charAsString(3);
  lexer.consume(3);
  return retval;
}
[...]