### PR TITLE
Exit SSL state machine loop if unwrap result in CLOSED

### DIFF
--- a/src/gov/nist/javax/sip/stack/SSLStateMachine.java
+++ b/src/gov/nist/javax/sip/stack/SSLStateMachine.java
@@ -341,6 +341,9 @@ public class SSLStateMachine {
 					}
 					continue;
 				}
+				if(result.getStatus().equals(Status.CLOSED)) {
+					break;
+				}
 				if(result.bytesProduced()>0) {
 					// There is actual application data in this chunk
 					dst.flip();


### PR DESCRIPTION
Recently I have observed that jsip based service consumes 100% cpu when handling single WSS connection. This has been caused by continuous GC caused by DirectByteBuffer allocation. Switching log level to debug showed me the following:
```
2021-02-05 16:42:53,369 DEBUG - Unwrap result Status = CLOSED HandshakeStatus = NEED_WRAP
bytesConsumed = 0 bytesProduced = 0 buffers size 0 src=java.nio.HeapByteBuffer[pos=24 lim=24 cap=24] dst=java.nio.DirectByteBuffer[pos=0 lim=16704 cap=16704]
2021-02-05 16:42:53,369 DEBUG - Buffer cleared
2021-02-05 16:42:53,369 DEBUG - NonAppWrap result Status = OK HandshakeStatus = NEED_WRAP
bytesConsumed = 0 bytesProduced = 0 buffers size 0
2021-02-05 16:42:53,369 DEBUG - Unwrap src java.nio.HeapByteBuffer[pos=24 lim=24 cap=24] dst java.nio.DirectByteBuffer[pos=0 lim=16704 cap=16704]
2021-02-05 16:42:53,369 DEBUG - Unwrap result Status = CLOSED HandshakeStatus = NEED_WRAP
bytesConsumed = 0 bytesProduced = 0 buffers size 0 src=java.nio.HeapByteBuffer[pos=24 lim=24 cap=24] dst=java.nio.DirectByteBuffer[pos=0 lim=16704 cap=16704]
2021-02-05 16:42:53,369 DEBUG - Buffer cleared
2021-02-05 16:42:53,369 DEBUG - NonAppWrap result Status = OK HandshakeStatus = NEED_WRAP
bytesConsumed = 0 bytesProduced = 0 buffers size 0
2021-02-05 16:42:53,369 DEBUG - Unwrap src java.nio.HeapByteBuffer[pos=24 lim=24 cap=24] dst java.nio.DirectByteBuffer[pos=0 lim=16704 cap=16704]
...
repeated many times
```
So I looked into SSLStateMachine and noticed that CLOSED status is ignored which seems to be cause of infinite loop. So PR is here.

Still this fix solves problem described about I'm not sure if it valid at all, at least if checking for closed state should go before checking number of bytes produced. Also it worth while to check wrap logic.