### PR TITLE
incomingPacket reference in UDPMessageChannel is kept, even if it is no longer needed.

### DIFF
--- a/src/gov/nist/javax/sip/stack/UDPMessageChannel.java
+++ b/src/gov/nist/javax/sip/stack/UDPMessageChannel.java
@@ -301,8 +301,7 @@ public class UDPMessageChannel extends MessageChannel implements
 	                	continue;
 	                } else {
 	                	packet = work.packet;
-		                this.incomingPacket = work.packet;						
-	                }	                	
+	                }
                 } catch (InterruptedException ex) {
 					if (!udpMessageProcessor.isRunning) {
 						return;
@@ -320,7 +319,7 @@ public class UDPMessageChannel extends MessageChannel implements
                 logger.logError(
                         "Error while processing incoming UDP packet" + Arrays.toString(packet.getData()), e);
             }
-
+            this.incomingPacket = null;
             if (sipStack.threadPoolSize == -1) {
                 return;
             }


### PR DESCRIPTION
When the thread pool size is set to unlimited, the incomingPacket reference can be freed after calling processIncomingDataPacket. DatagramPacket has a buffer with a default size of 64K, if there are many instances of UDPMessageChannel it causes unnecessary memory usage. As far as I can see, incomingPacket reference is not necessary if thread pool size is not unlimited, but the reference is set anyway, so I have removed that as well.