### PR TITLE
Support for multiple P-Access-Network-Info in SIP message 

### DIFF
--- a/src/gov/nist/javax/sip/header/ims/PAccessNetworkInfoList.java
+++ b/src/gov/nist/javax/sip/header/ims/PAccessNetworkInfoList.java
@@ -1,3 +1,28 @@
+/*
+* Conditions Of Use
+*
+* This software was developed by employees of the National Institute of
+* Standards and Technology (NIST), an agency of the Federal Government.
+* Pursuant to title 15 Untied States Code Section 105, works of NIST
+* employees are not subject to copyright protection in the United States
+* and are considered to be in the public domain.  As a result, a formal
+* license is not needed to use the software.
+*
+* This software is provided by NIST as a service and is expressly
+* provided "AS IS."  NIST MAKES NO WARRANTY OF ANY KIND, EXPRESS, IMPLIED
+* OR STATUTORY, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTY OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT
+* AND DATA ACCURACY.  NIST does not warrant or make any representations
+* regarding the use of the software or the results thereof, including but
+* not limited to the correctness, accuracy, reliability or usefulness of
+* the software.
+*
+* Permission to use this software is contingent upon your acceptance
+* of the terms of this agreement
+*
+* .
+*
+*/
 package gov.nist.javax.sip.header.ims;
 
 import gov.nist.javax.sip.header.SIPHeaderList;

--- a/src/gov/nist/javax/sip/header/ims/PAccessNetworkInfoList.java
+++ b/src/gov/nist/javax/sip/header/ims/PAccessNetworkInfoList.java
@@ -1,0 +1,40 @@
+package gov.nist.javax.sip.header.ims;
+
+import gov.nist.javax.sip.header.SIPHeaderList;
+
+
+/**
+ * List of P-Access-Network-Info headers
+ *
+ * @author Dipesh Kumar Sahu (IT) HPE
+ */
+
+/*
+ *  access-info            = cgi-3gpp / utran-cell-id-3gpp /
+                               dsl-location / i-wlan-node-id /
+                               ci-3gpp2 / eth-location /
+                               ci-3gpp2-femto / fiber-location /
+                               np / gstn-location /local-time-zone /
+                               dvb-rcs2-node-id / operator-specific-GI /
+                               utran-sai-3gpp / extension-access-info
+      np                     = "network-provided"
+      extension-access-info  = generic-param
+ */
+
+public class PAccessNetworkInfoList extends SIPHeaderList<PAccessNetworkInfo> {
+	
+	private static final long serialVersionUID = 563201040577795126L;
+	
+	/*
+	 * Default Construction
+	 */
+	public PAccessNetworkInfoList() {
+		super(PAccessNetworkInfo.class, PAccessNetworkInfoHeader.NAME);
+	}
+	
+	public Object clone() {
+		PAccessNetworkInfoList retval = new PAccessNetworkInfoList();
+        return retval.clonehlist(this.hlist);
+    }
+
+}

--- a/src/gov/nist/javax/sip/message/ListMap.java
+++ b/src/gov/nist/javax/sip/message/ListMap.java
@@ -82,6 +82,8 @@ import gov.nist.javax.sip.header.WWWAuthenticate;
 import gov.nist.javax.sip.header.WWWAuthenticateList;
 import gov.nist.javax.sip.header.Warning;
 import gov.nist.javax.sip.header.WarningList;
+import gov.nist.javax.sip.header.ims.PAccessNetworkInfo;
+import gov.nist.javax.sip.header.ims.PAccessNetworkInfoList;
 import gov.nist.javax.sip.header.ims.PAssertedIdentity;
 import gov.nist.javax.sip.header.ims.PAssertedIdentityList;
 import gov.nist.javax.sip.header.ims.PAssociatedURI;
@@ -208,6 +210,8 @@ public class ListMap {
         
         // https://java.net/jira/browse/JSIP-460
         headerListTable.put(Reason.class, ReasonList.class);
+        
+        headerListTable.put(PAccessNetworkInfo.class, PAccessNetworkInfoList.class);
 
         initialized = true;
 

--- a/src/gov/nist/javax/sip/parser/ims/PAccessNetworkInfoParser.java
+++ b/src/gov/nist/javax/sip/parser/ims/PAccessNetworkInfoParser.java
@@ -33,6 +33,7 @@ package gov.nist.javax.sip.parser.ims;
 import java.text.ParseException;
 
 import gov.nist.javax.sip.header.ims.PAccessNetworkInfo;
+import gov.nist.javax.sip.header.ims.PAccessNetworkInfoList;
 import gov.nist.javax.sip.header.ims.SIPHeaderNamesIms;
 import gov.nist.core.Token;
 import gov.nist.core.NameValue;
@@ -102,51 +103,59 @@ public class PAccessNetworkInfoParser
 
     public SIPHeader parse() throws ParseException
     {
-
-        if (debug)
+    	if (debug)
             dbg_enter("AccessNetworkInfoParser.parse");
-        try {
-            headerName(TokenTypes.P_ACCESS_NETWORK_INFO);
-            PAccessNetworkInfo accessNetworkInfo = new PAccessNetworkInfo();
-            accessNetworkInfo.setHeaderName(SIPHeaderNamesIms.P_ACCESS_NETWORK_INFO);
+        PAccessNetworkInfoList accessNetworkInfoList = new PAccessNetworkInfoList();
 
-            this.lexer.SPorHT();
-            lexer.match(TokenTypes.ID);
-            Token token = lexer.getNextToken();
-            accessNetworkInfo.setAccessType(token.getTokenValue());
-
-            this.lexer.SPorHT();
-            while (lexer.lookAhead(0) == ';') {
-                this.lexer.match(';');
-                this.lexer.SPorHT();
-
-                try {
-                	NameValue nv = super.nameValue('=');
-                	accessNetworkInfo.setParameter(nv);
-                } catch (ParseException e) {
-                	this.lexer.SPorHT();
-                	String ext = this.lexer.quotedString();
-                	if(ext == null) {
-                		ext = this.lexer.ttokenGenValue();
-                	} else {
-                		// avoids tokens such as "a=b" to be stripped of quotes and misinterpretend as
-                		// RFC 7913 generic-param when re-encoded
-                		ext = "\"" + ext + "\""; 
-                	}
-                	accessNetworkInfo.setExtensionAccessInfo(ext);
-                }
-                this.lexer.SPorHT();
-            }
-            this.lexer.SPorHT();
-            this.lexer.match('\n');
-
-
-            return accessNetworkInfo;
+        try{
+	        headerName(TokenTypes.P_ACCESS_NETWORK_INFO);
+	        while(true){
+		        PAccessNetworkInfo accessNetworkInfo = new PAccessNetworkInfo();
+		        accessNetworkInfo.setHeaderName(SIPHeaderNamesIms.P_ACCESS_NETWORK_INFO);
+		
+		        this.lexer.SPorHT();
+		        lexer.match(TokenTypes.ID);
+		        Token token = lexer.getNextToken();
+		        accessNetworkInfo.setAccessType(token.getTokenValue());
+		
+		        this.lexer.SPorHT();
+		        while (lexer.lookAhead(0) == ';') {
+		        	this.lexer.match(';');
+	                this.lexer.SPorHT();
+		        	try {
+	                	NameValue nv = super.nameValue('=');
+	                	accessNetworkInfo.setParameter(nv);
+	                } catch (ParseException e) {
+	                	this.lexer.SPorHT();
+	                	String ext = this.lexer.quotedString();
+	                	if(ext == null) {
+	                		ext = this.lexer.ttokenGenValue();
+	                	} else {
+	                		// avoids tokens such as "a=b" to be stripped of quotes and misinterpretend as
+	                		// RFC 7913 generic-param when re-encoded
+	                		ext = "\"" + ext + "\""; 
+	                	}
+	                	accessNetworkInfo.setExtensionAccessInfo(ext);
+	                }
+	                this.lexer.SPorHT();
+		        }
+		        accessNetworkInfoList.add(accessNetworkInfo);
+		        this.lexer.SPorHT();
+		        char la = lexer.lookAhead(0);
+	            if (la == ',') {
+	                this.lexer.match(',');
+	                this.lexer.SPorHT();
+	            } else if (la == '\n')
+	                break;
+	            else
+	                throw createParseException("unexpected char");
+	        }
+	
+	        return accessNetworkInfoList;
         } finally {
             if (debug)
-                dbg_leave("AccessNetworkInfoParser.parse");
+               dbg_leave("AccessNetworkInfoParser.parse");
         }
-
     }
 
 

--- a/src/gov/nist/javax/sip/parser/ims/PAccessNetworkInfoParser.java
+++ b/src/gov/nist/javax/sip/parser/ims/PAccessNetworkInfoParser.java
@@ -101,64 +101,60 @@ public class PAccessNetworkInfoParser
     }
 
 
-    public SIPHeader parse() throws ParseException
-    {
-    	if (debug)
-            dbg_enter("AccessNetworkInfoParser.parse");
-        PAccessNetworkInfoList accessNetworkInfoList = new PAccessNetworkInfoList();
+	public SIPHeader parse() throws ParseException {
+		if (debug)
+			dbg_enter("AccessNetworkInfoParser.parse");
+		PAccessNetworkInfoList accessNetworkInfoList = new PAccessNetworkInfoList();
 
-        try{
-	        headerName(TokenTypes.P_ACCESS_NETWORK_INFO);
-	        while(true){
-		        PAccessNetworkInfo accessNetworkInfo = new PAccessNetworkInfo();
-		        accessNetworkInfo.setHeaderName(SIPHeaderNamesIms.P_ACCESS_NETWORK_INFO);
-		
-		        this.lexer.SPorHT();
-		        lexer.match(TokenTypes.ID);
-		        Token token = lexer.getNextToken();
-		        accessNetworkInfo.setAccessType(token.getTokenValue());
-		
-		        this.lexer.SPorHT();
-		        while (lexer.lookAhead(0) == ';') {
-		        	this.lexer.match(';');
-	                this.lexer.SPorHT();
-		        	try {
-	                	NameValue nv = super.nameValue('=');
-	                	accessNetworkInfo.setParameter(nv);
-	                } catch (ParseException e) {
-	                	this.lexer.SPorHT();
-	                	String ext = this.lexer.quotedString();
-	                	if(ext == null) {
-	                		ext = this.lexer.ttokenGenValue();
-	                	} else {
-	                		// avoids tokens such as "a=b" to be stripped of quotes and misinterpretend as
-	                		// RFC 7913 generic-param when re-encoded
-	                		ext = "\"" + ext + "\""; 
-	                	}
-	                	accessNetworkInfo.setExtensionAccessInfo(ext);
-	                }
-	                this.lexer.SPorHT();
-		        }
-		        accessNetworkInfoList.add(accessNetworkInfo);
-		        this.lexer.SPorHT();
-		        char la = lexer.lookAhead(0);
-	            if (la == ',') {
-	                this.lexer.match(',');
-	                this.lexer.SPorHT();
-	            } else if (la == '\n')
-	                break;
-	            else
-	                throw createParseException("unexpected char");
-	        }
-	
-	        return accessNetworkInfoList;
-        } finally {
-            if (debug)
-               dbg_leave("AccessNetworkInfoParser.parse");
-        }
-    }
+		try {
+			headerName(TokenTypes.P_ACCESS_NETWORK_INFO);
+			while (true) {
+				PAccessNetworkInfo accessNetworkInfo = new PAccessNetworkInfo();
+				accessNetworkInfo.setHeaderName(SIPHeaderNamesIms.P_ACCESS_NETWORK_INFO);
 
+				this.lexer.SPorHT();
+				lexer.match(TokenTypes.ID);
+				Token token = lexer.getNextToken();
+				accessNetworkInfo.setAccessType(token.getTokenValue());
 
+				this.lexer.SPorHT();
+				while (lexer.lookAhead(0) == ';') {
+					this.lexer.match(';');
+					this.lexer.SPorHT();
+					try {
+						NameValue nv = super.nameValue('=');
+						accessNetworkInfo.setParameter(nv);
+					} catch (ParseException e) {
+						this.lexer.SPorHT();
+						String ext = this.lexer.quotedString();
+						if (ext == null) {
+							ext = this.lexer.ttokenGenValue();
+						} else {
+							// avoids tokens such as "a=b" to be stripped of quotes and misinterpretend as
+							// RFC 7913 generic-param when re-encoded
+							ext = "\"" + ext + "\"";
+						}
+						accessNetworkInfo.setExtensionAccessInfo(ext);
+					}
+					this.lexer.SPorHT();
+				}
+				accessNetworkInfoList.add(accessNetworkInfo);
+				this.lexer.SPorHT();
+				char la = lexer.lookAhead(0);
+				if (la == ',') {
+					this.lexer.match(',');
+					this.lexer.SPorHT();
+				} else if (la == '\n')
+					break;
+				else
+					throw createParseException("unexpected char");
+			}
 
+			return accessNetworkInfoList;
+		} finally {
+			if (debug)
+				dbg_leave("AccessNetworkInfoParser.parse");
+		}
+	}
 
 }

--- a/src/test/unit/gov/nist/javax/sip/parser/ims/PAccessNetworkInfoParserTest.java
+++ b/src/test/unit/gov/nist/javax/sip/parser/ims/PAccessNetworkInfoParserTest.java
@@ -48,6 +48,20 @@ public class PAccessNetworkInfoParserTest extends ParserTestCase
         };
 
         super.testParser(PAccessNetworkInfoParser.class,accessNetworkInfo);
+        
+        //test one more
+        String[] accessNetworkInfo_2 =  {
+                "P-Access-Network-Info: IEEE-802.11\n",
+                "P-Access-Network-Info: IEEE-802.11, 3GPP-UTRAN-TDD; utran-cell-id-3gpp=23456789ABCDE\n",
+                "P-Access-Network-Info: IEEE-802.11, 3GPP-UTRAN-TDD; utran-cell-id-3gpp=23456789ABCDE, 3GPP-UTRAN-TDD; utran-cell-id-3gpp=23456789ABCDF\n",
+                "P-Access-Network-Info: 3GPP-E-UTRAN; utran-cell-id-3gpp=262010063F423802;network-provided,3GPP-E-UTRAN-FDD; utran-cell-id-3gpp=262010063F423802\n",
+                "P-Access-Network-Info: IEEE-802.11;i-wlan-node-id=74da38582ba4\n",
+                "P-Access-Network-Info: 3GPP-E-UTRAN-FDD;utran-cell-id-3gpp=262010063f423802\n",
+                "P-Access-Network-Info: 3GPP-E-UTRAN;utran-cell-id-3gpp=\"262010063F423802\";network-provided,3GPP-E-UTRAN-FDD;utran-cell-id-3gpp=262010063f423802\n"
+        };
+        super.testParser(PAccessNetworkInfoParser.class,accessNetworkInfo_2);
+        
+
     }
 
 }


### PR DESCRIPTION
Added support for comma separated list of P-Access-Network-Info. 

Issue: #67 