### PR TITLE
Fix for issue #69 - Update to support corrected ABNF of P-Access-Network-Info header as per RFC  7913

### DIFF
--- a/src/gov/nist/core/LexerCore.java
+++ b/src/gov/nist/core/LexerCore.java
@@ -51,6 +51,7 @@ public class LexerCore extends StringTokenizer {
     public static final int WHITESPACE = END + 1;
     public static final int DIGIT = END + 2;
     public static final int ALPHA = END + 3;
+    public static final int IPV6 = END + 4;
     public static final int BACKSLASH = (int) '\\';
     public static final int QUOTE = (int) '\'';
     public static final int AT = (int) '@';
@@ -159,6 +160,12 @@ public class LexerCore extends StringTokenizer {
      */
     public String getNextId() {
         return ttoken();
+    }
+    
+    /** Get the next ip.
+     */
+    public String getNextIp() {
+        return tIpv6address();
     }
 
     public String getNextIdNoWhiteSpace() {
@@ -271,6 +278,11 @@ public class LexerCore extends StringTokenizer {
                 this.currentMatch.tokenType = tok;
                 consume(1);
 
+            } else if (tok == IPV6){
+                String ip = getNextIp();
+                this.currentMatch = new Token();
+                this.currentMatch.tokenValue = ip;
+                this.currentMatch.tokenType = IPV6;
             }
 
         } else {
@@ -407,6 +419,19 @@ public class LexerCore extends StringTokenizer {
                 }
             }
             return String.valueOf(buffer, startIdx, ptr - startIdx);
+        } catch (ParseException ex) {
+            return null;
+        }
+    }
+    
+    public String tIpv6address() {
+        try {
+            String hostName = String.valueOf(buffer, ptr, buffer.length - ptr );
+            HostNameParser hnp = new HostNameParser(hostName);
+            HostPort hp = hnp.hostPort(true);
+            int length = hp.getHost().hostname.length();
+            consume(length);
+            return hp.getHost().hostname;
         } catch (ParseException ex) {
             return null;
         }

--- a/src/gov/nist/javax/sip/parser/ims/PAccessNetworkInfoParser.java
+++ b/src/gov/nist/javax/sip/parser/ims/PAccessNetworkInfoParser.java
@@ -76,6 +76,9 @@ import gov.nist.javax.sip.parser.TokenTypes;
  *                                utran-sai-3gpp / extension-access-info
  *       np                     = "network-provided"
  *       extension-access-info  = generic-param
+ *  <p>As per RFC 3261 </p>
+ *      generic-param  =  token [ EQUAL gen-value ]
+ *      gen-value      =  token / host / quoted-string
  * </pre>
  * 
  *
@@ -122,7 +125,7 @@ public class PAccessNetworkInfoParser
 					this.lexer.match(';');
 					this.lexer.SPorHT();
 					try {
-						NameValue nv = super.nameValue('=');
+						NameValue nv = super.genericNameValue('=');
 						accessNetworkInfo.setParameter(nv);
 					} catch (ParseException e) {
 						this.lexer.SPorHT();

--- a/src/test/unit/gov/nist/javax/sip/parser/ims/PAccessNetworkInfoParserTest.java
+++ b/src/test/unit/gov/nist/javax/sip/parser/ims/PAccessNetworkInfoParserTest.java
@@ -60,8 +60,38 @@ public class PAccessNetworkInfoParserTest extends ParserTestCase
                 "P-Access-Network-Info: 3GPP-E-UTRAN;utran-cell-id-3gpp=\"262010063F423802\";network-provided,3GPP-E-UTRAN-FDD;utran-cell-id-3gpp=262010063f423802\n"
         };
         super.testParser(PAccessNetworkInfoParser.class,accessNetworkInfo_2);
-        
+        String token = "A1-.%*_+`'~";
+        String[] accessNetworkInfo_3 =  {
+                "P-Access-Network-Info: IEEE-802.11; network-provided\n",
+                 "P-Access-Network-Info: IEEE-802.11; ipv4=[2345:3456::]\n",
+                 //token
+                 "P-Access-Network-Info: "+token+"\n",
+                 //hostname
+                "P-Access-Network-Info: IEEE-802.11;AaB123=www.example-test.example.com\n",
+                "P-Access-Network-Info: IEEE-802.11;AaB123=www.example-test.example.com.\n",
+                //IPv4address 
+                "P-Access-Network-Info: IEEE-802.11;AaB123=1.1.1.1\n",
+                "P-Access-Network-Info: IEEE-802.11;AaB123=0.0.0.0\n",
+                //IPv6reference
+                "P-Access-Network-Info: IEEE-802.11;AaB123=[::]\n",
+                "P-Access-Network-Info: IEEE-802.11;AaB123=[88A]\n",
+                "P-Access-Network-Info: IEEE-802.11;AaB123=[88A::]\n",
+                "P-Access-Network-Info: IEEE-802.11;AaB123=[88A::99B]\n",
+                "P-Access-Network-Info: IEEE-802.11;AaB123=[88A:99B::]\n",
+                "P-Access-Network-Info: IEEE-802.11;AaB123=[88A:99B::11C]\n",
+                "P-Access-Network-Info: IEEE-802.11;AaB123=[88A:99B::11C:22D]\n",
+                "P-Access-Network-Info: IEEE-802.11;AaB123=[::11C]\n",
+                "P-Access-Network-Info: IEEE-802.11;AaB123=[11C::22D]\n",
+                //hexpart [ ":" IPv4address ]
+                "P-Access-Network-Info: IEEE-802.11;AaB123=[11C::12.04.02.99]\n",
+                //IPv6reference quoted
+                "P-Access-Network-Info: IEEE-802.11;AaB123=\"[11C::12.04.02.99]\"\n",
+                //Multiple IP6
+                "P-Access-Network-Info: IEEE-802.11;AaB123=[88A:99B::11C:22D];cc231=[11C::12.04.02.99]\n",
+        };
+        super.testParser(PAccessNetworkInfoParser.class,accessNetworkInfo_3);
 
     }
+
 
 }


### PR DESCRIPTION
Update to `P-Access-Network-Info` header parser to comply with corrected syntax by [RFC 7913](https://datatracker.ietf.org/doc/html/rfc7913).

Also white testing it has been found that the exiting function `ParserCore#nameValue()` does't support a IPV6 address. `ParserCore#genericNameValue()` is created to support `generic-param` format.  

