### PR TITLE
Fix for test AcceptLanguageParserTest that is broken by a patch of 2020

### DIFF
--- a/src/test/unit/gov/nist/javax/sip/parser/AcceptLanguageParserTest.java
+++ b/src/test/unit/gov/nist/javax/sip/parser/AcceptLanguageParserTest.java
@@ -26,7 +26,6 @@ public class AcceptLanguageParserTest extends ParserTestCase {
     public void testParser() {
         String data[] = { "Accept-Language:  da   \n",
                 "Accept-Language: \n", 
-                "Accept-Language: ,\n",
                 "Accept-Language: da, en-gb;q=0.8\n",
                 "Accept-Language: *\n" };
         super.testParser(AcceptLanguageParser.class,data);


### PR DESCRIPTION
Hi,
the test tries to encode **Accept-Language: ,**
which is not possible anymore since the fix of bug https://github.com/usnistgov/jsip/issues/53
I think it is legitimate to remove that test as the new behavior is better.