### PR TITLE
Fixed content-length computation for multipart-contents

### DIFF
--- a/src/gov/nist/javax/sip/message/SIPMessage.java
+++ b/src/gov/nist/javax/sip/message/SIPMessage.java
@@ -1429,7 +1429,11 @@ public abstract class SIPMessage extends MessageObject implements javax.sip.mess
             } else if (content instanceof byte[]) {
                 length = ((byte[]) content).length;
             } else {
-                length = content.toString().length();
+                try {
+                    length = content.toString().getBytes( getCharset() ).length;
+                } catch (UnsupportedEncodingException ex) {
+                    InternalErrorHandler.handleException(ex);
+                }
             }
         }
 


### PR DESCRIPTION
Added missing UTF-8 charset handling when calculating the length of a multipart content as it is also done when computing the length of a single content.
This fixes severe Content-Length issues when wrong encoded UTF-8 characters are used in content. When sending such characters by using the getRawContent() method they may be expanded from one to two bytes and the Content-Length would be wrong.