### PR TITLE
Support NOTIFY before 200 OK on a SUBSCRIBE

### DIFF
--- a/src/gov/nist/javax/sip/stack/SIPDialog.java
+++ b/src/gov/nist/javax/sip/stack/SIPDialog.java
@@ -3401,8 +3401,8 @@ public class SIPDialog implements javax.sip.Dialog, DialogExt {
                                         .getState() == DialogState.CONFIRMED
                                         && cseqMethod
                                                 .equals(Request.SUBSCRIBE)
-                                        && this.pendingRouteUpdateOn202Response && sipResponse
-                                        .getStatusCode() == Response.ACCEPTED))) {
+                                        && this.pendingRouteUpdateOn202Response && (sipResponse
+                                        .getStatusCode() == Response.ACCEPTED || sipResponse.getStatusCode() == Response.OK)))) {
                             if (this.getState() != DialogState.CONFIRMED) {
                                 setRemoteTag(sipResponse.getToTag());
                                 this
@@ -3425,7 +3425,8 @@ public class SIPDialog implements javax.sip.Dialog, DialogExt {
                              */
 
                             if (cseqMethod.equals(Request.SUBSCRIBE)
-                                    && sipResponse.getStatusCode() == Response.ACCEPTED
+                                    && (sipResponse
+                                    .getStatusCode() == Response.ACCEPTED || sipResponse.getStatusCode() == Response.OK)
                                     && this.pendingRouteUpdateOn202Response) {
                                 setRemoteTag(sipResponse.getToTag());
                                 this.addRoute(sipResponse);

--- a/src/gov/nist/javax/sip/stack/SIPServerTransactionImpl.java
+++ b/src/gov/nist/javax/sip/stack/SIPServerTransactionImpl.java
@@ -2063,7 +2063,6 @@ public class SIPServerTransactionImpl extends SIPTransactionImpl implements SIPS
             pendingReliableResponseAsBytes = null;
             pendingReliableResponseContentType = null;
             pendingReliableResponseMethod = null;
-            pendingSubscribeTransaction = null;
             provisionalResponseSem = null;
             retransmissionAlertTimerTask = null;
             requestOf = null;

--- a/src/gov/nist/javax/sip/stack/SIPServerTransactionImpl.java
+++ b/src/gov/nist/javax/sip/stack/SIPServerTransactionImpl.java
@@ -2066,6 +2066,7 @@ public class SIPServerTransactionImpl extends SIPTransactionImpl implements SIPS
             provisionalResponseSem = null;
             retransmissionAlertTimerTask = null;
             requestOf = null;
+            // Do not set pendingSubscribeTransaction to null because it is used after cleanUpOnTimer is executed
         }
     }
 

--- a/src/test/unit/gov/nist/javax/sip/stack/subsnotify/NotifyBefore202Test.java
+++ b/src/test/unit/gov/nist/javax/sip/stack/subsnotify/NotifyBefore202Test.java
@@ -1,5 +1,7 @@
 package test.unit.gov.nist.javax.sip.stack.subsnotify;
 
+import javax.sip.message.Response;
+
 import junit.framework.TestCase;
 
 public class NotifyBefore202Test  extends TestCase {
@@ -20,11 +22,21 @@ public class NotifyBefore202Test  extends TestCase {
 	/*
 	 * Non Regression test for issue http://java.net/jira/browse/JSIP-374
 	 */
-	public void testInDialogSubscribe() throws InterruptedException {
+	public void testInDialogSubscribeAfter202() throws InterruptedException {
 		subscriber.setInDialogSubcribe(true);
 		subscriber.sendSubscribe();
 		Thread.sleep(15000);
 		assertTrue(subscriber.checkState());
+		assertTrue(notifier.checkState());
+	}
+
+	public void testInDialogSubscribeAfter200() throws InterruptedException {
+		notifier.setSubscribeResponseCode(Response.OK);
+		subscriber.setInDialogSubcribe(true);
+		subscriber.sendSubscribe();
+		Thread.sleep(15000);
+		assertTrue(subscriber.checkState());
+		assertTrue(notifier.checkState());
 	}
 	
 	public void tearDown() throws Exception {		

--- a/src/test/unit/gov/nist/javax/sip/stack/subsnotify/Subscriber.java
+++ b/src/test/unit/gov/nist/javax/sip/stack/subsnotify/Subscriber.java
@@ -168,7 +168,6 @@ public class Subscriber implements SipListener {
 			try {
 				subscribe = subscriberDialog.createRequest(Request.SUBSCRIBE);
 				subscribe.addHeader(headerFactory.createExpiresHeader(0));
-				subscribe.setRequestURI(sipURI);
 				// Create an event header for the subscription.
 	            EventHeader eventHeader = headerFactory.createEventHeader("foo");
 	            eventHeader.setEventId("foo");


### PR DESCRIPTION
Currently, there is code to support receiving a NOTIFY before the 202 ACCEPTED on a SUBSCRIBE. That code is updating the remote target using the contact header of the 202 ACCEPTED. As specified in RFC 3265, a 200 OK can be the response of a SUBSCRIBE. When it happened, the code wasn't updating the remote target using the contact header, therefore, subsequent SUBSCRIBE on that dialog wasn't sent to the contact. I updated the code to support a 200 OK response.

I also updated the NotifyBefore202Test because it wasn't testing anything. 

Finally, on the cleanUpOnTimer, I removed the assignment to null for pendingSubscribeTransaction because it broke the support of receiving a NOTIFY before a 200/202.