### PR TITLE
New flag to disable auto 100 trying after 200ms

### DIFF
--- a/src/gov/nist/javax/sip/SipStackImpl.java
+++ b/src/gov/nist/javax/sip/SipStackImpl.java
@@ -576,6 +576,9 @@ import javax.sip.message.Request;
  * <li><b>gov.nist.javax.sip.SSL_RENEGOTIATION_ENABLED = [true|false]</b> Default value is <b>true</b>. Allow or disallow SSL renegotiation to resolve potential DoS problem - 
  * <a href="http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2011-1473">reference</a> and <a href="http://www.ietf.org/mail-archive/web/tls/current/msg07553.html">another reference</a>. The safe option is to disable it.</li>
  *
+ * <li><b>gov.nist.javax.sip.AUTOMATICALLY_SEND_TRYING_AFTER_200MS_ENABLED = [true|false]</b> Default value is <b>true</b>.
+ * The sip specification indicates that a 100 Trying should be send automatically after 200ms if no response has been sent.
+   This flag can be used to disable this behavior.</li>
  *
  * <li><b>javax.net.ssl.keyStore = fileName </b> <br/>
  * Default is <it>NULL</it>. If left undefined the keyStore and trustStore will
@@ -1489,7 +1492,11 @@ public class SipStackImpl extends SIPTransactionStack implements
 				"true"));
 		
 		setSslRenegotiationEnabled(sslRenegotiationEnabled);
-		
+
+    boolean automaticallySendTryingAfter200msEnabled = Boolean.parseBoolean(configurationProperties.getProperty(
+        "gov.nist.javax.sip.AUTOMATICALLY_SEND_TRYING_AFTER_200MS_ENABLED",
+        "true"));
+    setAutomaticallySendTryingAfter200msEnabled(automaticallySendTryingAfter200msEnabled);
 	}
 
 	/*

--- a/src/gov/nist/javax/sip/stack/SIPServerTransactionImpl.java
+++ b/src/gov/nist/javax/sip/stack/SIPServerTransactionImpl.java
@@ -679,7 +679,8 @@ public class SIPServerTransactionImpl extends SIPTransactionImpl implements SIPS
         if (realState < 0 || realState == TransactionState._TRYING) {
             // Also sent by intermediate proxies.
             // null check added as the stack may be stopped. TRYING is not sent by reliable transports.
-            if (isInviteTransaction() && !this.isMapped && sipStack.getTimer() != null ) {
+            // Can be disabled by config
+            if (isInviteTransaction() && !this.isMapped && sipStack.getTimer() != null && sipStack.isAutomaticallySendTryingAfter200msEnabled()) {
                 this.isMapped = true;
                 // Schedule a timer to fire in 200 ms if the
                 // TU did not send a trying in that time.

--- a/src/gov/nist/javax/sip/stack/SIPTransactionStack.java
+++ b/src/gov/nist/javax/sip/stack/SIPTransactionStack.java
@@ -415,6 +415,12 @@ public abstract class SIPTransactionStack implements
     
     private boolean sslRenegotiationEnabled = false;
     
+    /**
+     * The sip specification indicates that a 100 Trying should be send automatically after 200ms if no response has been sent.
+     * This is the default behavior. This flag can be used to disable this behavior.
+     */
+    private boolean automaticallySendTryingAfter200msEnabled = true;
+
     protected SocketTimeoutAuditor socketTimeoutAuditor = null;
 
     private static class SameThreadExecutor implements Executor {
@@ -3366,4 +3372,12 @@ public abstract class SIPTransactionStack implements
 	public void setSslRenegotiationEnabled(boolean sslRenegotiationEnabled) {
 		this.sslRenegotiationEnabled = sslRenegotiationEnabled;
 	}
+
+  public void setAutomaticallySendTryingAfter200msEnabled(boolean automaticallySendTryingAfter200msEnabled) {
+    this.automaticallySendTryingAfter200msEnabled = automaticallySendTryingAfter200msEnabled;
+  }
+
+  public boolean isAutomaticallySendTryingAfter200msEnabled() {
+    return automaticallySendTryingAfter200msEnabled;
+  }
 }

--- a/src/test/unit/gov/nist/javax/sip/stack/DialogEarlyStateTimeoutWithout100Test.java
+++ b/src/test/unit/gov/nist/javax/sip/stack/DialogEarlyStateTimeoutWithout100Test.java
@@ -1,0 +1,479 @@
+package test.unit.gov.nist.javax.sip.stack;
+
+import gov.nist.javax.sip.DialogTimeoutEvent;
+import gov.nist.javax.sip.ServerTransactionExt;
+import gov.nist.javax.sip.SipListenerExt;
+import gov.nist.javax.sip.SipProviderExt;
+import gov.nist.javax.sip.SipStackExt;
+import gov.nist.javax.sip.header.HeaderFactoryExt;
+import gov.nist.javax.sip.message.MessageFactoryExt;
+import gov.nist.javax.sip.stack.NioMessageProcessorFactory;
+
+import java.util.ArrayList;
+import java.util.Properties;
+
+import javax.sip.ClientTransaction;
+import javax.sip.Dialog;
+import javax.sip.DialogTerminatedEvent;
+import javax.sip.IOExceptionEvent;
+import javax.sip.ListeningPoint;
+import javax.sip.PeerUnavailableException;
+import javax.sip.RequestEvent;
+import javax.sip.ResponseEvent;
+import javax.sip.ServerTransaction;
+import javax.sip.SipFactory;
+import javax.sip.SipListener;
+import javax.sip.TimeoutEvent;
+import javax.sip.TransactionState;
+import javax.sip.TransactionTerminatedEvent;
+import javax.sip.address.Address;
+import javax.sip.address.AddressFactory;
+import javax.sip.address.SipURI;
+import javax.sip.header.CSeqHeader;
+import javax.sip.header.CallIdHeader;
+import javax.sip.header.ContactHeader;
+import javax.sip.header.ContentTypeHeader;
+import javax.sip.header.ExpiresHeader;
+import javax.sip.header.FromHeader;
+import javax.sip.header.MaxForwardsHeader;
+import javax.sip.header.RouteHeader;
+import javax.sip.header.ToHeader;
+import javax.sip.header.ViaHeader;
+import javax.sip.message.Request;
+import javax.sip.message.Response;
+
+import org.apache.log4j.ConsoleAppender;
+import org.apache.log4j.Logger;
+
+import test.unit.gov.nist.javax.sip.stack.CtxExpiredTest.Shootist;
+import test.unit.gov.nist.javax.sip.stack.CtxExpiredTest.Shootme;
+import junit.framework.TestCase;
+
+public class DialogEarlyStateTimeoutWithout100Test extends TestCase {
+    AddressFactory addressFactory;
+
+    HeaderFactoryExt headerFactory;
+
+    MessageFactoryExt messageFactory;
+
+    private Shootist shootist;
+
+    private Shootme shootme;
+
+    private SipStackExt shootistStack;
+
+    private SipStackExt shootmeStack;
+
+    private static String PEER_ADDRESS = Shootme.myAddress;
+
+    private static int PEER_PORT = Shootme.myPort;
+
+    private static String peerHostPort = PEER_ADDRESS + ":" + PEER_PORT;
+
+    private static Logger logger = Logger.getLogger(CtxExpiredTest.class);
+    static {
+        logger.addAppender(new ConsoleAppender());
+    }
+
+    class Shootist implements SipListenerExt {
+
+        protected static final String myAddress = "127.0.0.1";
+
+        protected static final int myPort = 6050;
+
+        private SipProviderExt provider;
+
+        private boolean saw1xx;
+
+        private ClientTransaction inviteTid;
+
+        private Dialog dialog;
+
+        private boolean timeoutSeen;
+
+        private Dialog timeoutDialog;
+
+        public void checkState() {
+            assertTrue("Should see timeout ", timeoutSeen);
+            assertFalse("Should NOT see 1xx ", saw1xx);
+            assertEquals("Dialog must be inviteDIalog", this.dialog,
+                    timeoutDialog);
+        }
+
+        public Shootist(SipStackExt sipStack) throws Exception {
+            ListeningPoint lp = sipStack.createListeningPoint("127.0.0.1",
+                    myPort, "udp");
+            this.provider = (SipProviderExt) sipStack.createSipProvider(lp);
+            provider.addSipListener(this);
+        }
+
+        public void sendInvite() {
+
+            try {
+
+                // Note that a provider has multiple listening points.
+                // all the listening points must have the same IP address
+                // and port but differ in their transport parameters.
+
+                String fromName = "BigGuy";
+                String fromSipAddress = "here.com";
+                String fromDisplayName = "The Master Blaster";
+
+                String toSipAddress = "there.com";
+                String toUser = "LittleGuy";
+                String toDisplayName = "The Little Blister";
+
+                // create >From Header
+                SipURI fromAddress = addressFactory.createSipURI(fromName,
+                        fromSipAddress);
+
+                Address fromNameAddress = addressFactory
+                        .createAddress(fromAddress);
+                fromNameAddress.setDisplayName(fromDisplayName);
+                FromHeader fromHeader = headerFactory.createFromHeader(
+                        fromNameAddress, new Integer(
+                                (int) (Math.random() * Integer.MAX_VALUE))
+                                .toString());
+
+                // create To Header
+                SipURI toAddress = addressFactory.createSipURI(toUser,
+                        toSipAddress);
+                Address toNameAddress = addressFactory.createAddress(toAddress);
+                toNameAddress.setDisplayName(toDisplayName);
+                ToHeader toHeader = headerFactory.createToHeader(toNameAddress,
+                        null);
+
+                // create Request URI
+                SipURI requestURI = addressFactory.createSipURI(toUser,
+                        peerHostPort);
+
+                // Create ViaHeaders
+
+                ArrayList viaHeaders = new ArrayList();
+                int port = provider.getListeningPoint("udp").getPort();
+
+                ViaHeader viaHeader = headerFactory.createViaHeader(myAddress,
+                        port, "udp", null);
+
+                // add via headers
+                viaHeaders.add(viaHeader);
+
+                // Create ContentTypeHeader
+                ContentTypeHeader contentTypeHeader = headerFactory
+                        .createContentTypeHeader("application", "sdp");
+
+                // Create a new CallId header
+                CallIdHeader callIdHeader = provider.getNewCallId();
+                // JvB: Make sure that the implementation matches the
+                // messagefactory
+                callIdHeader = headerFactory.createCallIdHeader(callIdHeader
+                        .getCallId());
+
+                // Create a new Cseq header
+                CSeqHeader cSeqHeader = headerFactory.createCSeqHeader(1L,
+                        Request.INVITE);
+
+                // Create a new MaxForwardsHeader
+                MaxForwardsHeader maxForwards = headerFactory
+                        .createMaxForwardsHeader(70);
+
+                // Create the request.
+                Request request = messageFactory.createRequest(requestURI,
+                        Request.INVITE, callIdHeader, cSeqHeader, fromHeader,
+                        toHeader, viaHeaders, maxForwards);
+                // Create contact headers
+
+                // Create the contact name address.
+                SipURI contactURI = addressFactory.createSipURI(fromName,
+                        myAddress);
+                contactURI.setPort(provider.getListeningPoint("udp").getPort());
+
+                Address contactAddress = addressFactory
+                        .createAddress(contactURI);
+
+                // Add the contact address.
+                contactAddress.setDisplayName(fromName);
+
+                ContactHeader contactHeader = headerFactory
+                        .createContactHeader(contactAddress);
+                request.addHeader(contactHeader);
+
+                String sdpData = "v=0\r\n"
+                        + "o=4855 13760799956958020 13760799956958020"
+                        + " IN IP4  129.6.55.78\r\n"
+                        + "s=mysession session\r\n" + "p=+46 8 52018010\r\n"
+                        + "c=IN IP4  129.6.55.78\r\n" + "t=0 0\r\n"
+                        + "m=audio 6022 RTP/AVP 0 4 18\r\n"
+                        + "a=rtpmap:0 PCMU/8000\r\n"
+                        + "a=rtpmap:4 G723/8000\r\n"
+                        + "a=rtpmap:18 G729A/8000\r\n" + "a=ptime:20\r\n";
+
+                request.setContent(sdpData, contentTypeHeader);
+
+                // The following is the preferred method to route requests
+                // to the peer. Create a route header and set the "lr"
+                // parameter for the router header.
+
+                Address address = addressFactory.createAddress("<sip:"
+                        + PEER_ADDRESS + ":" + PEER_PORT + ">");
+                // SipUri sipUri = (SipUri) address.getURI();
+                // sipUri.setPort(PEER_PORT);
+
+                RouteHeader routeHeader = headerFactory
+                        .createRouteHeader(address);
+                ((SipURI) address.getURI()).setLrParam();
+                request.addHeader(routeHeader);
+
+                // Create the client transaction.
+                this.inviteTid = provider.getNewClientTransaction(request);
+                this.dialog = this.inviteTid.getDialog();
+                // Note that the response may have arrived right away so
+                // we cannot check after the message is sent.
+                TestCase.assertTrue(this.dialog.getState() == null);
+
+                // send the request out.
+
+                this.inviteTid.sendRequest();
+
+            } catch (Exception ex) {
+                logger.error("Unexpected exception", ex);
+                TestCase.fail("unexpected exception");
+            }
+        }
+
+        
+        public void processDialogTerminated(
+                DialogTerminatedEvent dialogTerminatedEvent) {
+
+        }
+
+        
+        public void processIOException(IOExceptionEvent exceptionEvent) {
+            TestCase.fail("Unexpected event");
+        }
+
+        
+        public void processRequest(RequestEvent requestEvent) {
+            TestCase.fail("Unexpected event : processRequest");
+
+        }
+
+        
+        public void processResponse(ResponseEvent responseEvent) {
+
+            if (responseEvent.getResponse().getStatusCode() == 100) {
+                this.saw1xx = true;
+            }
+        }
+
+        
+        public void processTimeout(TimeoutEvent timeoutEvent) {
+            TestCase.fail("No timeout should be seen here");
+
+        }
+
+        
+        public void processTransactionTerminated(
+                TransactionTerminatedEvent transactionTerminatedEvent) {
+            logger.debug("Transaction Terminated Event seen");
+
+        }
+
+        
+        public void processDialogTimeout(DialogTimeoutEvent timeoutEvent) {
+            try {
+                this.timeoutSeen = true;
+                this.timeoutDialog = timeoutEvent.getDialog();
+                Dialog dialog = timeoutEvent.getDialog();
+                dialog.delete();
+                Request cancelRequest = inviteTid.createCancel();
+                ClientTransaction cancelTx = this.provider
+                        .getNewClientTransaction(cancelRequest);
+                cancelTx.sendRequest();
+            } catch (Exception exception) {
+                exception.printStackTrace();
+                logger.error("Unexpected exception", exception);
+                TestCase.fail("unexpected exception");
+            }
+
+        }
+
+    }
+
+    public class Shootme implements SipListener {
+
+        public static final int myPort = 6060;
+        public static final String myAddress = "127.0.0.1";
+        private SipProviderExt provider;
+        private boolean cancelSeen;
+        private boolean byeSeen;
+
+        public void checkState() {
+            TestCase.assertTrue("Should see cancel", cancelSeen);
+        }
+
+        public Shootme(SipStackExt sipStack) throws Exception {
+            ListeningPoint lp = sipStack.createListeningPoint("127.0.0.1",
+                    myPort, "udp");
+            this.provider = (SipProviderExt) sipStack.createSipProvider(lp);
+            provider.addSipListener(this);
+        }
+
+        
+        public void processDialogTerminated(
+                DialogTerminatedEvent dialogTerminatedEvent) {
+            // TODO Auto-generated method stub
+
+        }
+
+        
+        public void processIOException(IOExceptionEvent exceptionEvent) {
+            // TODO Auto-generated method stub
+
+        }
+
+        
+        public void processRequest(RequestEvent requestEvent) {
+            try {
+                Request request = requestEvent.getRequest();
+
+                if (request.getMethod().equals(Request.INVITE)) {
+                    if (requestEvent.getServerTransaction() == null) {
+
+                        ServerTransactionExt serverTransaction = (ServerTransactionExt) this.provider
+                                .getNewServerTransaction(request);
+                        Thread.sleep(1000);
+                        Response ringingResponse = messageFactory
+                                .createResponse(Response.RINGING, request);
+
+                        serverTransaction.sendResponse(ringingResponse);
+
+                    }
+                } else if (request.getMethod().equals(Request.CANCEL)) {
+                    ServerTransaction stx = requestEvent.getServerTransaction();
+                    Response okResponse = messageFactory.createResponse(200,
+                            request);
+                    stx.sendResponse(okResponse);
+                    this.cancelSeen = true;
+
+                } else if (request.getMethod().equals(Request.BYE)) {
+                    ServerTransaction stx = requestEvent.getServerTransaction();
+                    Response okResponse = messageFactory.createResponse(200,
+                            request);
+                    stx.sendResponse(okResponse);
+                    this.byeSeen = true;
+
+                }
+            } catch (Exception ex) {
+                logger.error("Unexpected exception", ex);
+                TestCase.fail("Unexpected exception");
+            }
+        }
+
+        
+        public void processResponse(ResponseEvent responseEvent) {
+            // TODO Auto-generated method stub
+
+        }
+
+        
+        public void processTimeout(TimeoutEvent timeoutEvent) {
+            // TODO Auto-generated method stub
+
+        }
+
+        
+        public void processTransactionTerminated(
+                TransactionTerminatedEvent transactionTerminatedEvent) {
+            // TODO Auto-generated method stub
+
+        }
+
+    }
+
+    
+    public void setUp() throws Exception {
+        SipFactory sipFactory = null;
+
+        sipFactory = SipFactory.getInstance();
+        sipFactory.setPathName("gov.nist");
+        Properties properties;
+
+        try {
+            headerFactory = (HeaderFactoryExt) sipFactory.createHeaderFactory();
+            addressFactory = sipFactory.createAddressFactory();
+            messageFactory = (MessageFactoryExt) sipFactory
+                    .createMessageFactory();
+
+        } catch (Exception ex) {
+            ex.printStackTrace();
+            fail("Unexpected exception");
+        }
+        try {
+            // Create SipStack object
+            properties = new Properties();
+
+            properties.setProperty("javax.sip.STACK_NAME", "shootist");
+            // You need 16 for logging traces. 32 for debug + traces.
+            // Your code will limp at 32 but it is best for debugging.
+            properties.setProperty("gov.nist.javax.sip.TRACE_LEVEL", "32");
+            properties.setProperty("gov.nist.javax.sip.DEBUG_LOG",
+                    "shootistdebug.txt");
+
+            properties.setProperty(
+                    "gov.nist.javax.sip.EARLY_DIALOG_TIMEOUT_SECONDS", "30");
+            if(System.getProperty("enableNIO") != null && System.getProperty("enableNIO").equalsIgnoreCase("true")) {
+            	logger.info("\nNIO Enabled\n");
+            	properties.setProperty("gov.nist.javax.sip.MESSAGE_PROCESSOR_FACTORY", NioMessageProcessorFactory.class.getName());
+            }
+            this.shootistStack = (SipStackExt) sipFactory
+                    .createSipStack(properties);
+            this.shootist = new Shootist(shootistStack);
+
+            // -----------------------------
+            properties = new Properties();
+
+            properties.setProperty("gov.nist.javax.sip.AUTOMATICALLY_SEND_TRYING_AFTER_200MS_ENABLED", "false");
+
+            properties.setProperty("javax.sip.STACK_NAME", "shootme");
+            // You need 16 for logging traces. 32 for debug + traces.
+            // Your code will limp at 32 but it is best for debugging.
+            properties.setProperty("gov.nist.javax.sip.TRACE_LEVEL", "32");
+            properties.setProperty("gov.nist.javax.sip.DEBUG_LOG",
+                    "shootmedebug.txt");
+            properties.setProperty(
+                    "gov.nist.javax.sip.EARLY_DIALOG_TIMEOUT_SECONDS", "30");
+            if(System.getProperty("enableNIO") != null && System.getProperty("enableNIO").equalsIgnoreCase("true")) {
+            	logger.info("\nNIO Enabled\n");
+            	properties.setProperty("gov.nist.javax.sip.MESSAGE_PROCESSOR_FACTORY", NioMessageProcessorFactory.class.getName());
+            }
+            this.shootmeStack = (SipStackExt) sipFactory
+                    .createSipStack(properties);
+            this.shootme = new Shootme(shootmeStack);
+
+        } catch (PeerUnavailableException e) {
+            // could not find
+            // gov.nist.jain.protocol.ip.sip.SipStackImpl
+            // in the classpath
+            e.printStackTrace();
+            System.err.println(e.getMessage());
+            if (e.getCause() != null)
+                e.getCause().printStackTrace();
+            TestCase.fail("Unexpected exception");
+        }
+
+    }
+
+    
+    public void tearDown() throws Exception {
+        Thread.sleep(50000);
+        this.shootist.checkState();
+        this.shootme.checkState();
+        this.shootistStack.stop();
+        this.shootmeStack.stop();
+    }
+
+    public void testSendInviteExpectTimeout() {
+        this.shootist.sendInvite();
+    }
+}


### PR DESCRIPTION
The sip specification indicates that a 100 Trying should be send automatically after 200ms if no response has been sent. This flag can be used to disable this behavior:  * gov.nist.javax.sip.AUTOMATICALLY_SEND_TRYING_AFTER_200MS_ENABLED = [true|false]Default value is true